### PR TITLE
Fix typo in link to Windows Docker Swarm blog post

### DIFF
--- a/Docker-Releases/Docker Swarm.md
+++ b/Docker-Releases/Docker Swarm.md
@@ -33,7 +33,7 @@ Now is a great time to ask all of your questions about Docker Swarm. Feel free t
 
 - [Getting Started with Docker Swarm] (http://collabnix.com/archives/967) by [Ajeet Singha Raina] (https://twitter.com/ajeetsraina)
 
-- [Run a local Windows Docker Swarm] (https://stefanscherer.github.io/build-your-local-windows-docker-swarm/0) by [Stefan Scherer](https://github.com/StefanScherer)
+- [Run a local Windows Docker Swarm] (https://stefanscherer.github.io/build-your-local-windows-docker-swarm/) by [Stefan Scherer](https://github.com/StefanScherer)
 
 - [One year+ feedback of using Docker and Swarm in DEV and QA environments] (https://medium.com/@frntn/one-year-feedback-of-using-docker-and-swarm-in-dev-and-qa-environments-deaf2ec6dc61#.j4rr4lkwv) by [Matthieu Fronton] (https://twitter.com/frntn)
  


### PR DESCRIPTION
There is a small typo in the link.