### PR TITLE
Fix typos in README

### DIFF
--- a/Campus Ambassadors/guidelines.md
+++ b/Campus Ambassadors/guidelines.md
@@ -10,7 +10,7 @@ You are responsible for keeping abreast of changes to this document. If you need
 
 # Embody the Docker Community Code of Conduct
 
-All Docker community members should strive to follow our community [Code of Conduct](https://github.com/docker/code-of-conduct).. As a Docker Campus Ambassador, it is especially important to lead by showing model behavior at all times, both in person and online.
+All Docker community members should strive to follow our community [Code of Conduct](https://github.com/docker/code-of-conduct). As a Docker Campus Ambassador, it is especially important to lead by showing model behavior at all times, both in person and online.
 
 # Understand Docker beyond containers.
 
@@ -26,7 +26,7 @@ In being a Campus Ambassador, you understand that Docker is an evolving platform
 
 # Curate balanced and accurate content
 
-- The Docker Community team will provide you with much of the content you need, including slide decks, training labs, information about new product releases tec but you are also welcome to accept talks from other members of the community.
+- The Docker Community team will provide you with much of the content you need, including slide decks, training labs, information about new product releases, etc but you are also welcome to accept talks from other members of the community.
 - When selecting content for you events and/or using program resources to produce content, prioritize featuring Docker-native solutions over others.
 - Be respectful when mentioning other vendors, technologies, and communities in the ecosystem.
 - Select content that is educational, accurate, and free from sales pitches.
@@ -34,14 +34,12 @@ In being a Campus Ambassador, you understand that Docker is an evolving platform
 - Be rigorous in assessing the content submitted by potential speakers. If you need help validating results and analyses, reach out to us for assistance.
 - When selecting events to promote, be sure the event features Docker-native solutions in a capacity and highlight that information in the body of the message.
 - If you experience difficulties with Docker products or programs, give us the opportunity to address your feedback in advance.
-- Make sure you're subscribed to the Docker Campus Ambassadors mailing list on Mobilize to stay informed about the latest Docker News and community activities
+- Make sure you're subscribed to the Docker Campus Ambassadors mailing list on Mobilize to stay informed about the latest Docker News and community activities.
 
 # Enforcing these Community Guidelines
- 
+
 Docker reserves the right to remove any member from the Campus Ambassadors program for violating these guidelines. In the event of a violation, the Docker community team will review the situation and determine the consequences on a case by case basis. When a Campus Ambassador is removed from the program, we retire the remaining benefits and his or her access to Docker Campus Ambassadors resources.
 
 # Next Steps
 
-If you are comfortable with the above information and confident that you can abide by these guidelines please [apply to be an official Docker Campus Ambassador here](https://community.docker.com/registrations/groups/9355 "Application") and we will be in touch shortly.
-
-
+If you are comfortable with the above information and confident that you can abide by these guidelines please [apply to be an official Docker Campus Ambassador here](https://community.docker.com/registrations/groups/9355) and we will be in touch shortly.

--- a/Docker-Meetup-Content/Docker 1.12.md
+++ b/Docker-Meetup-Content/Docker 1.12.md
@@ -1,22 +1,22 @@
 ## Slides
-- [What's New in Docker 1.12] (http://www.slideshare.net/Docker/whats-new-in-docker-112-by-mike-goelzer-and-andrea-luzzardi)
+- [What's New in Docker 1.12](http://www.slideshare.net/Docker/whats-new-in-docker-112-by-mike-goelzer-and-andrea-luzzardi)
 
 ## Videos
-- [Docker Online Meetup #40: Docker 1.12] (https://www.youtube.com/watch?v=joFYGbqjLBc)
-- [Datacenter Docker 1.12 introduction and live demo] (https://www.youtube.com/watch?v=vE1iDPx6-Ok&feature=youtu.be&t=53m50s)
-- [Docker 1.12 at Zenly by Steeve Morin and Jean-Baptiste Dalido] (https://www.youtube.com/watch?v=vE1iDPx6-Ok&feature=youtu.be&t=1h25m25s)
-- [DockerCon Docker Track: Mike Goelzer - What's New in Docker 1.12] (https://www.youtube.com/watch?v=FgXJKw37po8&feature=youtu.be)
+- [Docker Online Meetup #40: Docker 1.12](https://www.youtube.com/watch?v=joFYGbqjLBc)
+- [Datacenter Docker 1.12 introduction and live demo](https://www.youtube.com/watch?v=vE1iDPx6-Ok&feature=youtu.be&t=53m50s)
+- [Docker 1.12 at Zenly by Steeve Morin and Jean-Baptiste Dalido](https://www.youtube.com/watch?v=vE1iDPx6-Ok&feature=youtu.be&t=1h25m25s)
+- [DockerCon Docker Track: Mike Goelzer - What's New in Docker 1.12](https://www.youtube.com/watch?v=FgXJKw37po8&feature=youtu.be)
 
 ## Articles
-- [Docker 1.12 release notes] (https://docs.docker.com/release-notes/)
-- [Docker 1.12: Now with Built-in Orchestration!] (https://blog.docker.com/2016/06/docker-1-12-built-in-orchestration/)
-- [Docker Online Meetup #40: Docker 1.12] (https://blog.docker.com/2016/07/docker-online-meetup-40-docker-1-12/)
-- [Scale a real microservice with Docker 1.12 Swarm Mode by Docker Captain Alex Ellis] (http://blog.alexellis.io/microservice-swarm-mode/)
-- [Docker 1.12 orchestration built-in by Docker Captain Gianluca Arbezzano] (http://gianarb.it/blog/docker-1-12-orchestration-built-in)
-- [Swarm Reboot in Docker 1.12] (http://www.skippbox.com/swarm-reboot-in-docker-1-12/)
+- [Docker 1.12 release notes](https://docs.docker.com/release-notes/)
+- [Docker 1.12: Now with Built-in Orchestration!](https://blog.docker.com/2016/06/docker-1-12-built-in-orchestration/)
+- [Docker Online Meetup #40: Docker 1.12](https://blog.docker.com/2016/07/docker-online-meetup-40-docker-1-12/)
+- [Scale a real microservice with Docker 1.12 Swarm Mode by Docker Captain Alex Ellis](http://blog.alexellis.io/microservice-swarm-mode/)
+- [Docker 1.12 orchestration built-in by Docker Captain Gianluca Arbezzano](http://gianarb.it/blog/docker-1-12-orchestration-built-in)
+- [Swarm Reboot in Docker 1.12](http://www.skippbox.com/swarm-reboot-in-docker-1-12/)
 
 ## Resources
-- [Working Example: HelloWorld using docker 1.12] (https://github.com/tomwillfixit/helloworld)
-- [Working Example: Adding a healthcheck to container image using Docker 1.12] (https://github.com/tomwillfixit/healthcheck)
-- [Lab: Updated Docker for Java lab with 1.12] (https://github.com/docker/labs/tree/master/java)
-- [Lab: Docker Swarm Mode Tutorials] (https://github.com/docker/labs/tree/master/swarm-mode)
+- [Working Example: HelloWorld using docker 1.12](https://github.com/tomwillfixit/helloworld)
+- [Working Example: Adding a healthcheck to container image using Docker 1.12](https://github.com/tomwillfixit/healthcheck)
+- [Lab: Updated Docker for Java lab with 1.12](https://github.com/docker/labs/tree/master/java)
+- [Lab: Docker Swarm Mode Tutorials](https://github.com/docker/labs/tree/master/swarm-mode)

--- a/Docker-Meetup-Content/Docker 1.13.md
+++ b/Docker-Meetup-Content/Docker 1.13.md
@@ -1,19 +1,19 @@
-# Blog post 
+# Blog post
 
 -  [Introducing Docker 1.13](https://blog.docker.com/2017/01/whats-new-in-docker-1-13/)
-- [Docker Online Meetup Recap: Introducing Docker 1.13.0] (https://blog.docker.com/2017/01/docker-online-meetup-recap-introducing-docker-1-13/)
-- [What’s New in Docker Engine 1.13 Swarm Mode?] (http://collabnix.com/archives/2381) by [Ajeet Singh Raina] (https://twitter.com/ajeetsraina)
-- [Using Docker Stack And Compose YAML Files To Deploy Swarm Services] (https://technologyconversations.com/2017/01/23/using-docker-stack-and-compose-yaml-files-to-deploy-swarm-services) by [Viktor Farcic] (https://twitter.com/vfarcic)
-- [Deploy Docker Compose Services to Swarm] (http://blog.arungupta.me/deploy-docker-compose-services-swarm) by [Arun Gupta] (https://twitter.com/arungupta)
-- [What’s New in Docker 1.13] (http://blog.arungupta.me/docker-1-13-management-commands) by [Laura Frank] (https://twitter.com/rhein_wein)
-- [Docker 1.13 Management Commands] (http://blog.arungupta.me/docker-1-13-management-commands/) by [Arun Gupta] (https://twitter.com/arungupta)
+- [Docker Online Meetup Recap: Introducing Docker 1.13.0](https://blog.docker.com/2017/01/docker-online-meetup-recap-introducing-docker-1-13/)
+- [What’s New in Docker Engine 1.13 Swarm Mode?](http://collabnix.com/archives/2381) by [Ajeet Singh Raina](https://twitter.com/ajeetsraina)
+- [Using Docker Stack And Compose YAML Files To Deploy Swarm Services](https://technologyconversations.com/2017/01/23/using-docker-stack-and-compose-yaml-files-to-deploy-swarm-services) by [Viktor Farcic](https://twitter.com/vfarcic)
+- [Deploy Docker Compose Services to Swarm](http://blog.arungupta.me/deploy-docker-compose-services-swarm) by [Arun Gupta](https://twitter.com/arungupta)
+- [What’s New in Docker 1.13](http://blog.arungupta.me/docker-1-13-management-commands) by [Laura Frank](https://twitter.com/rhein_wein)
+- [Docker 1.13 Management Commands](http://blog.arungupta.me/docker-1-13-management-commands/) by [Arun Gupta](https://twitter.com/arungupta)
 
 # Video
 
 - [Docker 1.13 video](https://www.youtube.com/watch?v=y_RiG_9jEJ0)
-- [Docker Online Meetup: What's new in Docker 1.13.0] (https://youtu.be/W6MVBMZDsbk) 
+- [Docker Online Meetup: What's new in Docker 1.13.0](https://youtu.be/W6MVBMZDsbk)
 
-# Slides 
+# Slides
 
 - [Docker 1.13 slides](https://docs.google.com/presentation/d/1yrG94vTwWv4UCmDV7fXEDHNhjbWppvRUYqrbHBJCHTA/edit?usp=sharing)
-- [Docker Online Meetup: What's new in docker 1.13.0] (http://www.slideshare.net/Docker/online-meetup-whats-new-in-docker-1130)
+- [Docker Online Meetup: What's new in docker 1.13.0](http://www.slideshare.net/Docker/online-meetup-whats-new-in-docker-1130)

--- a/Docker-Meetup-Content/Docker 1.9.md
+++ b/Docker-Meetup-Content/Docker 1.9.md
@@ -2,30 +2,29 @@
 - [Docker 1.9 Release video] (https://www.youtube.com/watch?v=wtHkh4gIU70)
 - [Docker 1.9 Release Blog Post](http://blog.docker.com/2015/11/docker-1-9-production-ready-swarm-multi-host-networking)
 - [Docker 1.9 Slides](http://www.slideshare.net/Docker/docker-platform-19)
-- [Docker Engine 1.9 Release Notes] (https://github.com/docker/docker/blob/master/CHANGELOG.md)
-- [Docker Machine 0.4 release Notes] (https://github.com/docker/machine/blob/master/CHANGELOG.md)
+- [Docker Engine 1.9 Release Notes](https://github.com/docker/docker/blob/master/CHANGELOG.md)
+- [Docker Machine 0.4 release Notes](https://github.com/docker/machine/blob/master/CHANGELOG.md)
 - [Docker Swarm 1.0 release Notes](https://github.com/docker/swarm/blob/master/CHANGELOG.md)
 - [Docker Compose 1.5 release Notes](https://github.com/docker/compose/releases/tag/1.5.0)
 - [Docker Registry 2.2 release Notes](https://github.com/docker/distribution/releases/tag/v2.2.0)
-- [Docker 1.9 documentation] (https://docs.docker.com/installation/)
+- [Docker 1.9 documentation](https://docs.docker.com/installation/)
 
 # Docker Multi Host Networking demo
 
-- [Video] (https://www.youtube.com/watch?v=B2wd_UigNxU)
+- [Video](https://www.youtube.com/watch?v=B2wd_UigNxU)
 - [Demo Script](https://github.com/dave-tucker/docker-network-demos/blob/master/multihost-local.sh)
 - [Multi Host Networking Blog Post](http://blog.docker.com/2015/11/docker-multi-host-networking-ga)
 
-# Docker Multi Host Networking and Docker Swarm Demo 
+# Docker Multi Host Networking and Docker Swarm Demo
 
 - [Video] (https://www.youtube.com/watch?v=MJL0ANWcxZM)
 - [Demo Script](https://github.com/dave-tucker/docker-network-demos/blob/master/swarm-local.sh)
 - [Multi Host Networking Blog Post](http://blog.docker.com/2015/11/docker-multi-host-networking-ga)
-- [Swarm 1.0 Blog Post] (http://blog.docker.com/2015/11/swarm-1-0)
+- [Swarm 1.0 Blog Post](http://blog.docker.com/2015/11/swarm-1-0)
 
-# Docker Multi Host Networking with Docker Swarm and Docker Compose Demo 
+# Docker Multi Host Networking with Docker Swarm and Docker Compose Demo
 
-- [Video] (https://www.youtube.com/watch?v=Fi2rwjYwRAg)
+- [Video](https://www.youtube.com/watch?v=Fi2rwjYwRAg)
 - [Demo Script](https://github.com/dave-tucker/docker-network-demos/tree/master/counter)
 - [Multi Host Networking Blog Post](http://blog.docker.com/2015/11/docker-multi-host-networking-ga)
-- [Swarm 1.0 Blog Post] (http://blog.docker.com/2015/11/swarm-1-0)
-
+- [Swarm 1.0 Blog Post](http://blog.docker.com/2015/11/swarm-1-0)

--- a/Docker-Meetup-Content/Docker Cloud.md
+++ b/Docker-Meetup-Content/Docker Cloud.md
@@ -1,18 +1,18 @@
 ## Slides
 
-- [Slides] (https://docs.google.com/presentation/d/1OCz47f3-fN9fCHMOax6R3-MQkwAQ8pBaYXuQWszUzpo/edit)
-- [CI/CD with Docker Cloud] (http://www.slideshare.net/Docker/docker-meetup-at-docker-hq-docker-cloud?ref=https://blog.docker.com/2016/06/docker-cloud-meetup/)
-- [How Fairfly Uses Docker Cloud: Overview + Demo] (https://docs.google.com/presentation/d/1JXu4B5n5WdVXRLh995nvwNRb3N0K1i4fBa5mu4M8ZfU/edit#slide=id.g12843f461e_2_87)
+- [Slides](https://docs.google.com/presentation/d/1OCz47f3-fN9fCHMOax6R3-MQkwAQ8pBaYXuQWszUzpo/edit)
+- [CI/CD with Docker Cloud](http://www.slideshare.net/Docker/docker-meetup-at-docker-hq-docker-cloud?ref=https://blog.docker.com/2016/06/docker-cloud-meetup/)
+- [How Fairfly Uses Docker Cloud: Overview + Demo](https://docs.google.com/presentation/d/1JXu4B5n5WdVXRLh995nvwNRb3N0K1i4fBa5mu4M8ZfU/edit#slide=id.g12843f461e_2_87)
 
 ##Videos
-- [Docker Cloud Meetup at Docker HQ] (https://www.youtube.com/watch?list=PLkA60AVN3hh9-7WqDqBqDRtVVIXydSM-_&v=FBzNqhhOJBs)
-- [Docker Cloud: Deploy your first application] (https://www.youtube.com/watch?v=dmW0Xi4D3WU)
-- [Docker Cloud Overview] (https://www.youtube.com/watch?v=VW1RIWMQOg0)
+- [Docker Cloud Meetup at Docker HQ](https://www.youtube.com/watch?list=PLkA60AVN3hh9-7WqDqBqDRtVVIXydSM-_&v=FBzNqhhOJBs)
+- [Docker Cloud: Deploy your first application](https://www.youtube.com/watch?v=dmW0Xi4D3WU)
+- [Docker Cloud Overview](https://www.youtube.com/watch?v=VW1RIWMQOg0)
 
 ## Articles
 
-- [Docker Cloud Docs] (https://docs.docker.com/docker-cloud/)
-- [Docker Cloud Release Notes] (https://docs.docker.com/docker-cloud/release-notes/)
-- [4 no-bull takeaways about Docker Cloud] (http://www.infoworld.com/article/3040475/application-virtualization/4-no-bull-takeaways-about-docker-cloud.html)
-- [Docker Security Scanning now available to Docker cloud users] (http://www.zdnet.com/article/docker-security-scanning-now-available-to-docker-cloud-users/)
-- [Docker Cloud to the Rescue] (https://blog.docker.com/2016/04/docker-cloud-3blades/)
+- [Docker Cloud Docs](https://docs.docker.com/docker-cloud/)
+- [Docker Cloud Release Notes](https://docs.docker.com/docker-cloud/release-notes/)
+- [4 no-bull takeaways about Docker Cloud](http://www.infoworld.com/article/3040475/application-virtualization/4-no-bull-takeaways-about-docker-cloud.html)
+- [Docker Security Scanning now available to Docker cloud users](http://www.zdnet.com/article/docker-security-scanning-now-available-to-docker-cloud-users/)
+- [Docker Cloud to the Rescue](https://blog.docker.com/2016/04/docker-cloud-3blades/)

--- a/Docker-Meetup-Content/Docker Security.md
+++ b/Docker-Meetup-Content/Docker Security.md
@@ -3,33 +3,28 @@
 
 # Slides
 
-### [Securing the Software Supply Chain with Docker Security] (https://docs.google.com/presentation/d/1dCsJzGhA2WMV8pLiGOrH_uFKIeKPP2EV-Q3BdWcjtnk/edit?usp=sharing)
-### [Enterprise Production Grade Secrets Management] (http://www.slideshare.net/secret/57Y3KZrGuWB38N)
+### [Securing the Software Supply Chain with Docker Security](https://docs.google.com/presentation/d/1dCsJzGhA2WMV8pLiGOrH_uFKIeKPP2EV-Q3BdWcjtnk/edit?usp=sharing)
+### [Enterprise Production Grade Secrets Management](http://www.slideshare.net/secret/57Y3KZrGuWB38N)
 ### [Deep diving into Docker Security](https://speakerdeck.com/akalipetis/docker-security-internals)
 *feel free to use and modify these slides!*
 
 
 # Videos
 
-- [Hump Day Demo: Docker Security Scanning] (https://docker.wistia.com/medias/32v44sv52b) by [Chris Hines] (https://www.linkedin.com/in/christopher-c-hines-5356883b), [Mario Ponticello] (https://www.linkedin.com/in/marioponticello) and [Toli Kuznets] (https://www.linkedin.com/in/tolikuznets)
+- [Hump Day Demo: Docker Security Scanning](https://docker.wistia.com/medias/32v44sv52b) by [Chris Hines](https://www.linkedin.com/in/christopher-c-hines-5356883b), [Mario Ponticello](https://www.linkedin.com/in/marioponticello) and [Toli Kuznets](https://www.linkedin.com/in/tolikuznets)
 
-- [Docker Trusted Registry and Docker Content Trust] (https://www.youtube.com/watch?v=5LGmkh_F1ZA) by Docker Captain [Elton Stoneman] (https://twitter.com/EltonStoneman)
+- [Docker Trusted Registry and Docker Content Trust](https://www.youtube.com/watch?v=5LGmkh_F1ZA) by Docker Captain [Elton Stoneman](https://twitter.com/EltonStoneman)
 
 # Resources
 
-- [Introducing Docker Secrets Management] (https://blog.docker.com/2017/02/docker-secrets-management/)
-- [Manage sensitive data with Docker secrets] (https://docs.docker.com/engine/swarm/secrets/)
-- [Docker Knowledge Hub FAQ: Docker Security Scanning] (https://success.docker.com/Cloud/FAQ%3A_Docker_Security_Scanning)
+- [Introducing Docker Secrets Management](https://blog.docker.com/2017/02/docker-secrets-management/)
+- [Manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/)
+- [Docker Knowledge Hub FAQ: Docker Security Scanning](https://success.docker.com/Cloud/FAQ%3A_Docker_Security_Scanning)
 
 # Blog posts
 
-- [Introducing Docker Datacenter On 1.13 With Secrets, Security Scanning, Content Cache And More] (https://blog.docker.com/2017/02/docker-datacenter-1-13/) by [Banjot Chanana] (https://blog.docker.com/author/banjot/)
-- [Secrets and LIE-abilities: The State of Modern Secret Management (2017)] (https://medium.com/on-docker/secrets-and-lie-abilities-the-state-of-modern-secret-management-2017-c82ec9136a3d#.soo96tt3q) by [Docker Captain, Jeff Nickoloff] (https://twitter.com/allingeek)
-- [Docker Security Scanning safeguards the container content lifecycle] (https://blog.docker.com/2016/05/docker-security-scanning/) by [Lily Guo] (https://www.linkedin.com/in/lilybguo), [Toli Kuznets] (https://www.linkedin.com/in/tolikuznets) and [Nandhini Santhanam] (https://www.linkedin.com/in/nandhini915)
-- [Alpine Linux and Docker Nautilus Protect Crate Images] (https://crate.io/a/alpine-linux-and-docker-nautilus-protect-crate/) by [Nils Magnus] (https://twitter.com/craternils)
-- [A Look Back at One Year of Docker Security] (https://blog.docker.com/2016/04/docker-security/) by [Diogo Mónica] (https://twitter.com/diogomonica)
-
-
-
-
-
+- [Introducing Docker Datacenter On 1.13 With Secrets, Security Scanning, Content Cache And More](https://blog.docker.com/2017/02/docker-datacenter-1-13/) by [Banjot Chanana](https://blog.docker.com/author/banjot/)
+- [Secrets and LIE-abilities: The State of Modern Secret Management (2017)](https://medium.com/on-docker/secrets-and-lie-abilities-the-state-of-modern-secret-management-2017-c82ec9136a3d#.soo96tt3q) by [Docker Captain, Jeff Nickoloff](https://twitter.com/allingeek)
+- [Docker Security Scanning safeguards the container content lifecycle](https://blog.docker.com/2016/05/docker-security-scanning/) by [Lily Guo](https://www.linkedin.com/in/lilybguo), [Toli Kuznets](https://www.linkedin.com/in/tolikuznets) and [Nandhini Santhanam](https://www.linkedin.com/in/nandhini915)
+- [Alpine Linux and Docker Nautilus Protect Crate Images](https://crate.io/a/alpine-linux-and-docker-nautilus-protect-crate/) by [Nils Magnus](https://twitter.com/craternils)
+- [A Look Back at One Year of Docker Security](https://blog.docker.com/2016/04/docker-security/) by [Diogo Mónica](https://twitter.com/diogomonica)

--- a/Docker-Meetup-Content/Docker Swarm.md
+++ b/Docker-Meetup-Content/Docker Swarm.md
@@ -9,12 +9,12 @@
 - [Docker Swarm Mode full tutorial](https://github.com/docker/labs/blob/master/swarm-mode/beginner-tutorial/README.md)
 - [Service deployment on a swarm in the Cloud](https://github.com/docker/labs/blob/master/swarm-mode/cloud-quick-start/README.md)
 - [Docker Orchestration - Getting Started With Swarm Mode](https://www.katacoda.com/courses/docker-orchestration/getting-started-with-swarm-mode)
-- [Docker Swarm Mode Lab] (https://www.youtube.com/playlist?list=PLKWiGyDcaq_ZT_dYqneTxsc5OglDrj_ap)
-- 
+- [Docker Swarm Mode Lab](https://www.youtube.com/playlist?list=PLKWiGyDcaq_ZT_dYqneTxsc5OglDrj_ap)
+-
 
 # Slides
 
-- [Understanding Docker Swarm] (https://speakerdeck.com/akalipetis/understanding-docker-swarm-mode)
+- [Understanding Docker Swarm](https://speakerdeck.com/akalipetis/understanding-docker-swarm-mode)
 - [Heart of the SwarmKit: Store, Topology & Object Model](http://www.slideshare.net/Docker/heart-of-the-swarmkit-store-topology-object-model)
 
 
@@ -24,13 +24,13 @@
 
 - [Docker Captains Share Tips & Tricks for Using Docker 1.12 ](https://www.youtube.com/watch?v=2ihqKMDRkxM)
 
-- [Docker 1.12 Swarm Mode Deep Dive Part 1: Topology] (https://www.youtube.com/watch?v=dooPhkXT9yI&list=PLkA60AVN3hh-jd4zGpRWHG8LIQUpBXBsM&index=1)
+- [Docker 1.12 Swarm Mode Deep Dive Part 1: Topology](https://www.youtube.com/watch?v=dooPhkXT9yI&list=PLkA60AVN3hh-jd4zGpRWHG8LIQUpBXBsM&index=1)
 
-- [Docker 1.12 Swarm Mode Deep Dive Part 2: Orchestration] (https://www.youtube.com/watch?v=_F6PSP-qhdA&list=PLkA60AVN3hh-jd4zGpRWHG8LIQUpBXBsM&index=2)
+- [Docker 1.12 Swarm Mode Deep Dive Part 2: Orchestration](https://www.youtube.com/watch?v=_F6PSP-qhdA&list=PLkA60AVN3hh-jd4zGpRWHG8LIQUpBXBsM&index=2)
 
-- [Introduction to Docker 1.12] (https://www.youtube.com/watch?v=joFYGbqjLBc&list=PLkA60AVN3hh-2UPoaft7u7ofKW2mLoAWB&index=24)
+- [Introduction to Docker 1.12](https://www.youtube.com/watch?v=joFYGbqjLBc&list=PLkA60AVN3hh-2UPoaft7u7ofKW2mLoAWB&index=24)
 
-- [Docker Swarm Mode Walkthrough] (https://www.youtube.com/watch?v=KC4Ad1DS8xU)
+- [Docker Swarm Mode Walkthrough](https://www.youtube.com/watch?v=KC4Ad1DS8xU)
 
 
 # Blog posts
@@ -49,7 +49,7 @@
 
 - [Scale ASP.NET Core apps with Docker Swarm Mode](http://tutorials.pluralsight.com/microsoft-net/scale-asp-net-core-apps-with-docker-swarm-mode#pjGkrjwDTc32bZrY.99)
 
-- [Docker 1.12 Swarm Mode - round robin inside and out] (http://blog.scottlogic.com/2016/08/30/docker-1-12-swarm-mode-round-robin.html)
+- [Docker 1.12 Swarm Mode - round robin inside and out](http://blog.scottlogic.com/2016/08/30/docker-1-12-swarm-mode-round-robin.html)
 
 ## Networking in Swarm Mode
 

--- a/Docker-Meetup-Content/Docker for Mac & Windows.md
+++ b/Docker-Meetup-Content/Docker for Mac & Windows.md
@@ -1,10 +1,10 @@
 ## Slides
 
-- [Slides] (https://docs.google.com/presentation/d/1fmTlA-K6-XwJYpMrDbye5-4WGsBmqYYkENNrNGbsiWg/edit#slide=id.p4)
-- [Docker for Windows Beta] (http://stefanscherer.github.io/talks/20160428_DockerMeetupBamberg_DockerForWindowsBeta/#1) by [Stefan Scherer] (https://twitter.com/stefscherer)
+- [Slides](https://docs.google.com/presentation/d/1fmTlA-K6-XwJYpMrDbye5-4WGsBmqYYkENNrNGbsiWg/edit#slide=id.p4)
+- [Docker for Windows Beta](http://stefanscherer.github.io/talks/20160428_DockerMeetupBamberg_DockerForWindowsBeta/#1) by [Stefan Scherer] (https://twitter.com/stefscherer)
 
 ## Articles
 
-- [Docker For Windows Beta] (http://docker-saigon.github.io/post/Docker-Beta/)
-- [First touch with Docker for Mac] (http://blog.hypriot.com/post/first-touch-down-with-docker-for-mac/)
+- [Docker For Windows Beta](http://docker-saigon.github.io/post/Docker-Beta/)
+- [First touch with Docker for Mac](http://blog.hypriot.com/post/first-touch-down-with-docker-for-mac/)
 - [Introduction to Docker for Mac/Windows](https://speakerdeck.com/akalipetis/docker-for-mac-windows) by [Antonis Kalipetis](https://twitter.com/akalipetis)

--- a/Docker-Meetup-Content/Docker-Datacenter.md
+++ b/Docker-Meetup-Content/Docker-Datacenter.md
@@ -2,16 +2,16 @@
 
 ### Slides
 
-- [What's New in DDC] (https://docs.google.com/presentation/d/1OzTKr4BWO6PrRIFJ3Mp7GVnYHY6ivUxrnbbHcKP48rE/edit?usp=sharing)
+- [What's New in DDC](https://docs.google.com/presentation/d/1OzTKr4BWO6PrRIFJ3Mp7GVnYHY6ivUxrnbbHcKP48rE/edit?usp=sharing)
 
-- [DDC Technical Overview] (https://docs.google.com/presentation/d/1ZVSmAn8C-sJopWUntLZCeRe4JBjqRr6NdwWKll2mXQM/edit?usp=sharing)
+- [DDC Technical Overview](https://docs.google.com/presentation/d/1ZVSmAn8C-sJopWUntLZCeRe4JBjqRr6NdwWKll2mXQM/edit?usp=sharing)
 
 
 ### Video
 
-- [DockerCon Demo of DDC] (https://youtu.be/KC9tJ7b3dww?t=16m24s)
+- [DockerCon Demo of DDC](https://youtu.be/KC9tJ7b3dww?t=16m24s)
 
-- [What's New in Docker Datacenter with Engine 1.12 ] (https://www.youtube.com/watch?v=9MjSzMO3euQ)
+- [What's New in Docker Datacenter with Engine 1.12 ](https://www.youtube.com/watch?v=9MjSzMO3euQ)
 
 
 ### Blog posts
@@ -35,4 +35,4 @@
 
 - [Datasheet](http://www.docker.com/sites/default/files/Docker_Datacenter_Brochure_11.13.16.pdf)
 
-- [What's New in DDC Hand out] (https://drive.google.com/file/d/0B-DZLVOtmtcESnhKcy03ZmEtb0dGeTFHYW0yUnJNMVU0ZEI0/view?usp=sharing)
+- [What's New in DDC Hand out](https://drive.google.com/file/d/0B-DZLVOtmtcESnhKcy03ZmEtb0dGeTFHYW0yUnJNMVU0ZEI0/view?usp=sharing)

--- a/Docker-Meetup-Content/DockerCon 2016.md
+++ b/Docker-Meetup-Content/DockerCon 2016.md
@@ -4,142 +4,142 @@
 
 ## Videos
 
-- [Introduction by Ben Golub and Solomon Hykes] (https://youtu.be/vE1iDPx6-Ok?t=1s)
-- [Docker for developers by Aanand Prasad] (https://youtu.be/vE1iDPx6-Ok?t=34m45s)
-- [Guest speaker #1: Matt Aimonetti, CTO and Co-founder of Splice] (https://youtu.be/vE1iDPx6-Ok?t=46m10s)
-- [Docker 1.12 introduction and live demo] (https://youtu.be/vE1iDPx6-Ok?t=53m50s)
-- [Docker 1.12 at Zenly by Steeve Morin and Jean-Baptiste Dalido] (https://youtu.be/vE1iDPx6-Ok?t=1h25m25s)
-- [Docker for AWS and Azure demo by Aanand Prasad and Madhu] (https://youtu.be/vE1iDPx6-Ok?t=1h29m30s)
+- [Introduction by Ben Golub and Solomon Hykes](https://youtu.be/vE1iDPx6-Ok?t=1s)
+- [Docker for developers by Aanand Prasad](https://youtu.be/vE1iDPx6-Ok?t=34m45s)
+- [Guest speaker #1: Matt Aimonetti, CTO and Co-founder of Splice](https://youtu.be/vE1iDPx6-Ok?t=46m10s)
+- [Docker 1.12 introduction and live demo](https://youtu.be/vE1iDPx6-Ok?t=53m50s)
+- [Docker 1.12 at Zenly by Steeve Morin and Jean-Baptiste Dalido](https://youtu.be/vE1iDPx6-Ok?t=1h25m25s)
+- [Docker for AWS and Azure demo by Aanand Prasad and Madhu](https://youtu.be/vE1iDPx6-Ok?t=1h29m30s)
 
 ## Slides
 
-- [Day 1 General Session Slides] (https://docs.google.com/presentation/d/1pVoVhHiQFVKKBrQTmXXimQMb4IMg2f5JN1hENurseo4/edit?usp=sharing)
+- [Day 1 General Session Slides](https://docs.google.com/presentation/d/1pVoVhHiQFVKKBrQTmXXimQMb4IMg2f5JN1hENurseo4/edit?usp=sharing)
 
 ## Articles
 
-- [Docker Automates and Democratizes Container Orchestration] (http://www.docker.com/docker-news-and-press/docker-automates-and-democratizes-container-orchestration)
-- [Docker 1.12: Now with Built-in Orchestration!] (https://blog.docker.com/2016/06/docker-1-12-built-in-orchestration/)
-- [Announcing the Docker for Mac and Windows Public Beta] (https://blog.docker.com/2016/06/docker-mac-windows-public-beta/)
-- [Introducing the Docker for AWS and Azure Beta] (https://blog.docker.com/2016/06/azure-aws-beta/)
-- [Introducing Experimental Distributed Application Bundles] (https://blog.docker.com/2016/06/docker-app-bundle/)
-- [How Docker for Mac helps me sleep better at night] (https://blog.docker.com/2016/06/docker-for-mac-splice/)
+- [Docker Automates and Democratizes Container Orchestration](http://www.docker.com/docker-news-and-press/docker-automates-and-democratizes-container-orchestration)
+- [Docker 1.12: Now with Built-in Orchestration!](https://blog.docker.com/2016/06/docker-1-12-built-in-orchestration/)
+- [Announcing the Docker for Mac and Windows Public Beta](https://blog.docker.com/2016/06/docker-mac-windows-public-beta/)
+- [Introducing the Docker for AWS and Azure Beta](https://blog.docker.com/2016/06/azure-aws-beta/)
+- [Introducing Experimental Distributed Application Bundles](https://blog.docker.com/2016/06/docker-app-bundle/)
+- [How Docker for Mac helps me sleep better at night](https://blog.docker.com/2016/06/docker-for-mac-splice/)
 
 ##Day 2: General Session
 
 ## Videos
 
-- [Docker in production for the Enterprise by Ben Golub] (https://youtu.be/KC9tJ7b3dww?t=1s)
-- [Docker Datacenter in production demo by Vivek Saraswat and Lily Guo] (https://youtu.be/KC9tJ7b3dww?t=21m50s)
-- [Guest speaker #1: Docker and Microsoft demo by Mark Russinovich, CTO Microsoft Azure] (https://youtu.be/KC9tJ7b3dww?t=47m)
-- [Guest speaker #2: Docker at ADP by Keith Fulton, CTO] (https://youtu.be/KC9tJ7b3dww?t=1h6m)
+- [Docker in production for the Enterprise by Ben Golub](https://youtu.be/KC9tJ7b3dww?t=1s)
+- [Docker Datacenter in production demo by Vivek Saraswat and Lily Guo](https://youtu.be/KC9tJ7b3dww?t=21m50s)
+- [Guest speaker #1: Docker and Microsoft demo by Mark Russinovich, CTO Microsoft Azure](https://youtu.be/KC9tJ7b3dww?t=47m)
+- [Guest speaker #2: Docker at ADP by Keith Fulton, CTO](https://youtu.be/KC9tJ7b3dww?t=1h6m)
 
 
 ## Slides
 
-- [Day 2 General Session Slides: Morning] (https://docs.google.com/presentation/d/1Tc_FXJ3rKkbmg4LppAdNONxFlnP0vfnBpZpWDtcyJKU/edit?usp=sharing)
-- [Day 2 General Session Slides: Afternoon] (https://docs.google.com/presentation/d/1KcXyf_vUD7SHc_NB-MZXo7QBzA9jghw2AztSiYQ_iwQ/edit?usp=sharing)
+- [Day 2 General Session Slides: Morning](https://docs.google.com/presentation/d/1Tc_FXJ3rKkbmg4LppAdNONxFlnP0vfnBpZpWDtcyJKU/edit?usp=sharing)
+- [Day 2 General Session Slides: Afternoon](https://docs.google.com/presentation/d/1KcXyf_vUD7SHc_NB-MZXo7QBzA9jghw2AztSiYQ_iwQ/edit?usp=sharing)
 
 ## Articles
 
-- [Introducing the Docker Store Private Beta] (https://blog.docker.com/2016/06/docker-store/)
-- [Docker Datacenter in AWS and Azure in a few clicks] (https://blog.docker.com/2016/06/docker-datacenter-aws-azure-cloud/)
-- [Docker Datacenter user samples] (https://blog.docker.com/2016/06/docker-datacenter-enterprise/)
+- [Introducing the Docker Store Private Beta](https://blog.docker.com/2016/06/docker-store/)
+- [Docker Datacenter in AWS and Azure in a few clicks](https://blog.docker.com/2016/06/docker-datacenter-aws-azure-cloud/)
+- [Docker Datacenter user samples](https://blog.docker.com/2016/06/docker-datacenter-enterprise/)
 
 
 ##Tracks: Docker, Docker, Docker
 
 ## Videos
 
-- [Docker for Enterprise by Banjot Channa] (https://youtu.be/NSxi8oix748)
-- [Docker for Ops: Operationalize your Docker Built Apps in Production by Evan Hazlett and Vivek Saraswat] (https://youtu.be/H8VULs3JTsU)
-- [Docker for Ops: Docker Storage and Volumes Deep Dive and considerations by Brian Goff] (https://youtu.be/X_q2l8hotAc)
-- [Docker for Ops: Docker Networking Deep Dive, Considerations and Troubleshooting by Madhu Venugopal and Jana Radhakrishnan] (https://youtu.be/Gwdo3fo6pZg)
-- [What's New in Docker 1.12] (https://youtu.be/FgXJKw37po8)
+- [Docker for Enterprise by Banjot Channa](https://youtu.be/NSxi8oix748)
+- [Docker for Ops: Operationalize your Docker Built Apps in Production by Evan Hazlett and Vivek Saraswat](https://youtu.be/H8VULs3JTsU)
+- [Docker for Ops: Docker Storage and Volumes Deep Dive and considerations by Brian Goff](https://youtu.be/X_q2l8hotAc)
+- [Docker for Ops: Docker Networking Deep Dive, Considerations and Troubleshooting by Madhu Venugopal and Jana Radhakrishnan](https://youtu.be/Gwdo3fo6pZg)
+- [What's New in Docker 1.12](https://youtu.be/FgXJKw37po8)
 
 ## Slides
 
-- [What's New in Docker 1.12] (http://www.slideshare.net/Docker/whats-new-in-docker-112-by-mike-goelzer-and-andrea-luzzardi)
-- [Docker for Developers - part 1] (http://www.slideshare.net/Docker/docker-for-developers-part-1-by-david-gageot)
-- [Docker for Developers - part 2] (http://www.slideshare.net/Docker/docker-for-developers-part-2-by-borja-burgos-and-fernando-mayo)
-- [Docker for the Enterprise] (https://docs.google.com/a/docker.com/presentation/d/1q3r4HpBLt0nt2qFNY05GrsD-BatMQ1fwifbJKYtXIYM/edit?usp=sharing)
-- [Docker Security Deep Dive] (http://www.slideshare.net/Docker/docker-security-deep-dive-by-ying-li-and-david-lawrence)
-- [Docker for Ops: Operationalize your Docker Built Apps in Production] (https://docs.google.com/a/docker.com/presentation/d/1Ll54BDGAmlARq5FurGX9VUX9-Xh5XUdtPWRr3FJAflI/edit?usp=sharing)
-- [Docker for Ops: Extending Docker with APIs, Drivers and Plugins] (https://docs.google.com/a/docker.com/presentation/d/1KHaQIBwjFy2orkadqVWscKf4FaMtMoUmfxIudkjfDNg/edit?usp=sharing)
-- [Docker for Ops: Docker Storage and Volumes Deep Dive and Considerations] (https://docs.google.com/a/docker.com/presentation/d/1IDJan3bhnFrfUfYEkpyxmHOZIylEjoiVJnKlv5ur-7s/edit?usp=sharing)
-- [Docker for Ops: Docker Networking Deep Dive, Considerations and Troubleshooting] (https://docs.google.com/a/docker.com/presentation/d/1_xW7y6I09sN6MwnYGyFhwhU7AS9dhjgJi_kJkOQdGLY/edit?usp=sharing)
+- [What's New in Docker 1.12](http://www.slideshare.net/Docker/whats-new-in-docker-112-by-mike-goelzer-and-andrea-luzzardi)
+- [Docker for Developers - part 1](http://www.slideshare.net/Docker/docker-for-developers-part-1-by-david-gageot)
+- [Docker for Developers - part 2](http://www.slideshare.net/Docker/docker-for-developers-part-2-by-borja-burgos-and-fernando-mayo)
+- [Docker for the Enterprise](https://docs.google.com/a/docker.com/presentation/d/1q3r4HpBLt0nt2qFNY05GrsD-BatMQ1fwifbJKYtXIYM/edit?usp=sharing)
+- [Docker Security Deep Dive](http://www.slideshare.net/Docker/docker-security-deep-dive-by-ying-li-and-david-lawrence)
+- [Docker for Ops: Operationalize your Docker Built Apps in Production](https://docs.google.com/a/docker.com/presentation/d/1Ll54BDGAmlARq5FurGX9VUX9-Xh5XUdtPWRr3FJAflI/edit?usp=sharing)
+- [Docker for Ops: Extending Docker with APIs, Drivers and Plugins](https://docs.google.com/a/docker.com/presentation/d/1KHaQIBwjFy2orkadqVWscKf4FaMtMoUmfxIudkjfDNg/edit?usp=sharing)
+- [Docker for Ops: Docker Storage and Volumes Deep Dive and Considerations](https://docs.google.com/a/docker.com/presentation/d/1IDJan3bhnFrfUfYEkpyxmHOZIylEjoiVJnKlv5ur-7s/edit?usp=sharing)
+- [Docker for Ops: Docker Networking Deep Dive, Considerations and Troubleshooting](https://docs.google.com/a/docker.com/presentation/d/1_xW7y6I09sN6MwnYGyFhwhU7AS9dhjgJi_kJkOQdGLY/edit?usp=sharing)
 
 ##Tracks: Wildcard
 
 ## Videos
 
-- [Containers and VMs and Cloud: Oh My by Mike Coleman, Docker] (https://youtu.be/aeeaQZT9rBQ)
-- [The Dockerfile Explosion and the Need for Higher Level Tools by Gareth Rushgrove, Puppet] (https://youtu.be/IyuyA8rSBAo)
-- [Immutable Awesomeness by Josh Corman, Sonatype and John Willis, Docker] (https://youtu.be/-Y_ZhvEaZX8)
-- [Efficient Parallel Testing with Docker by Docker Captain Laura Frank, Codeship] (https://youtu.be/N3pPjYxLvkY)
-- [Deploying Personalized Learning Labs using Docker Swarm by Nate Aune, Appsembler and Brian Dant, Appsembler] (https://youtu.be/SMwC39zxXY8)
-- [Making Friendly Microservices by Michele Titolo, Capital One] (https://youtu.be/zRg7pIS3TjM)
-- [Dockerizing CS50: From Cluster to Cloud to Appliance to Container by David J. Malan, Harvard and Dan Armendariz, Harvard] (https://youtu.be/KUPb4n8YB3g)
-- [It Takes an Ecosystem to Build a Production Application by Narayan Annamalai, Microsoft and Ross Gardler, Microsoft] (https://youtu.be/IRDcRlwq-Hw)
+- [Containers and VMs and Cloud: Oh My by Mike Coleman, Docker](https://youtu.be/aeeaQZT9rBQ)
+- [The Dockerfile Explosion and the Need for Higher Level Tools by Gareth Rushgrove, Puppet](https://youtu.be/IyuyA8rSBAo)
+- [Immutable Awesomeness by Josh Corman, Sonatype and John Willis, Docker](https://youtu.be/-Y_ZhvEaZX8)
+- [Efficient Parallel Testing with Docker by Docker Captain Laura Frank, Codeship](https://youtu.be/N3pPjYxLvkY)
+- [Deploying Personalized Learning Labs using Docker Swarm by Nate Aune, Appsembler and Brian Dant, Appsembler](https://youtu.be/SMwC39zxXY8)
+- [Making Friendly Microservices by Michele Titolo, Capital One](https://youtu.be/zRg7pIS3TjM)
+- [Dockerizing CS50: From Cluster to Cloud to Appliance to Container by David J. Malan, Harvard and Dan Armendariz, Harvard](https://youtu.be/KUPb4n8YB3g)
+- [It Takes an Ecosystem to Build a Production Application by Narayan Annamalai, Microsoft and Ross Gardler, Microsoft](https://youtu.be/IRDcRlwq-Hw)
 
 ## Slides
 
-- [Containers and VMs and Cloud: Oh My by Mike Coleman, Docker] (http://www.slideshare.net/Docker/containers-and-vms-and-clouds-oh-my-by-mike-coleman)
-- [The Dockerfile Explosion and the Need for Higher Level Tools by Gareth Rushgrove, Puppet] (http://www.slideshare.net/Docker/the-dockerfile-explosion-and-the-need-for-higher-level-tools-by-gareth-rushgrove)
-- [Immutable Awesomeness by Josh Corman, Sonatype and John Willis, Docker] (http://www.slideshare.net/Docker/immutable-awesomeness-by-john-willis-and-josh-corman)
-- [Efficient Parallel Testing with Docker by Docker Captain Laura Frank, Codeship] (http://www.slideshare.net/Docker/efficient-parallel-testing-with-docker-by-laura-frank)
-- [Deploying Personalized Learning Labs using Docker Swarm by Nate Aune, Appsembler and Brian Dant, Appsembler] (http://www.slideshare.net/Docker/deploying-personalized-learning-labs-using-docker-swarm-by-nate-aune-and-brian-dant)
-- [Making Friendly Microservices by Michele Titolo, Capital One] (http://www.slideshare.net/Docker/making-friendly-microservices-by-michele-titlol)
-- [Dockerizing CS50: From Cluster to Cloud to Appliance to Container by David J. Malan, Harvard and Dan Armendariz, Harvard] (http://www.slideshare.net/Docker/dockerizing-cs50-from-cluster-to-cloud-to-appliance-to-container-by-david-malan-and-david-armendariz)
-- [It Takes an Ecosystem to Build a Production Application by Narayan Annamalai, Microsoft and Ross Gardler, Microsoft] (http://www.slideshare.net/Docker/it-takes-an-ecosystem-to-build-a-production-application-by-ross-gardler)
+- [Containers and VMs and Cloud: Oh My by Mike Coleman, Docker](http://www.slideshare.net/Docker/containers-and-vms-and-clouds-oh-my-by-mike-coleman)
+- [The Dockerfile Explosion and the Need for Higher Level Tools by Gareth Rushgrove, Puppet](http://www.slideshare.net/Docker/the-dockerfile-explosion-and-the-need-for-higher-level-tools-by-gareth-rushgrove)
+- [Immutable Awesomeness by Josh Corman, Sonatype and John Willis, Docker](http://www.slideshare.net/Docker/immutable-awesomeness-by-john-willis-and-josh-corman)
+- [Efficient Parallel Testing with Docker by Docker Captain Laura Frank, Codeship](http://www.slideshare.net/Docker/efficient-parallel-testing-with-docker-by-laura-frank)
+- [Deploying Personalized Learning Labs using Docker Swarm by Nate Aune, Appsembler and Brian Dant, Appsembler](http://www.slideshare.net/Docker/deploying-personalized-learning-labs-using-docker-swarm-by-nate-aune-and-brian-dant)
+- [Making Friendly Microservices by Michele Titolo, Capital One](http://www.slideshare.net/Docker/making-friendly-microservices-by-michele-titlol)
+- [Dockerizing CS50: From Cluster to Cloud to Appliance to Container by David J. Malan, Harvard and Dan Armendariz, Harvard](http://www.slideshare.net/Docker/dockerizing-cs50-from-cluster-to-cloud-to-appliance-to-container-by-david-malan-and-david-armendariz)
+- [It Takes an Ecosystem to Build a Production Application by Narayan Annamalai, Microsoft and Ross Gardler, Microsoft](http://www.slideshare.net/Docker/it-takes-an-ecosystem-to-build-a-production-application-by-ross-gardler)
 
-##Tracks: Black Belt 
+##Tracks: Black Belt
 
 ## Videos
 
-- [The Golden Ticket: Docker and High Security Microservices by Aaron Grattafiori] (https://youtu.be/346WmxQ5xtk)
-- [Cloning Running Servers with Docker and CRIU by Ross Boucher, Playground Theory] (https://youtu.be/1lCiWaLHwxo)
-- [Docker for Mac and Windows: The Insider’s Guide by Justin Cormack, Docker] (https://youtu.be/7da-B3rY9V4)
-- [Containerd: Building a Container Supervisor by Michael Crosby, Docker] (https://youtu.be/VWuHWfEB6ro)
-- [Windows Server and Docker – The Internals Behind Bringing Docker and Containers to Windows by Taylor Brown, Microsoft and John Starks, Microsoft] (https://youtu.be/85nCF5S8Qok)
-- [Getting Deep on Orchestration: APIs, Actors, and Abstractions in a Distributed System by Docker Captain Jeff Nickoloff, All in Geek Consulting] (https://youtu.be/Ozem3R12--w)
-- [runC: The little engine that could run Docker containers by Docker Captain Phil Estes, IBM] (https://youtu.be/ZAhzoz2zJj8)
-- [Unikernels and Docker: From Revolution to Evolution by Mindy Preston, Docker] (https://youtu.be/0AZVCGTxkTU)
-- [Sharding Containers: Make Go Apps Computer-Friendly Again by Andrey Sibiryov, Uber] (https://youtu.be/5lGVCPQeqiM)
+- [The Golden Ticket: Docker and High Security Microservices by Aaron Grattafiori](https://youtu.be/346WmxQ5xtk)
+- [Cloning Running Servers with Docker and CRIU by Ross Boucher, Playground Theory](https://youtu.be/1lCiWaLHwxo)
+- [Docker for Mac and Windows: The Insider’s Guide by Justin Cormack, Docker](https://youtu.be/7da-B3rY9V4)
+- [Containerd: Building a Container Supervisor by Michael Crosby, Docker](https://youtu.be/VWuHWfEB6ro)
+- [Windows Server and Docker – The Internals Behind Bringing Docker and Containers to Windows by Taylor Brown, Microsoft and John Starks, Microsoft](https://youtu.be/85nCF5S8Qok)
+- [Getting Deep on Orchestration: APIs, Actors, and Abstractions in a Distributed System by Docker Captain Jeff Nickoloff, All in Geek Consulting](https://youtu.be/Ozem3R12--w)
+- [runC: The little engine that could run Docker containers by Docker Captain Phil Estes, IBM](https://youtu.be/ZAhzoz2zJj8)
+- [Unikernels and Docker: From Revolution to Evolution by Mindy Preston, Docker](https://youtu.be/0AZVCGTxkTU)
+- [Sharding Containers: Make Go Apps Computer-Friendly Again by Andrey Sibiryov, Uber](https://youtu.be/5lGVCPQeqiM)
 
 ## Slides
 
-- [The Golden Ticket: Docker and High Security Microservices by Aaron Grattafiori] (http://www.slideshare.net/Docker/the-golden-ticket-docker-and-high-security-microservices-by-aaron-grattafiori)
-- [Cloning Running Servers with Docker and CRIU by Ross Boucher, Playground Theory] (http://www.slideshare.net/Docker/cloning-running-servers-with-docker-and-criu-by-ross-boucher)
-- [Docker for Mac and Windows: The Insider’s Guide by Justin Cormack, Docker] (http://www.slideshare.net/Docker/docker-for-mac-and-windows-the-insiders-guide-by-justin-cormack)
-- [Containerd: Building a Container Supervisor by Michael Crosby, Docker] (http://www.slideshare.net/Docker/containerd-building-a-container-supervisor-by-michael-crosby)
-- [Windows Server and Docker – The Internals Behind Bringing Docker and Containers to Windows by Taylor Brown, Microsoft and John Starks, Microsoft] (http://www.slideshare.net/Docker/windows-server-and-docker-the-internals-behind-bringing-docker-and-containers-to-windows-by-taylor-brown-and-john-starks)
-- [Getting Deep on Orchestration: APIs, Actors, and Abstractions in a Distributed System by Docker Captain Jeff Nickoloff, All in Geek Consulting] (http://www.slideshare.net/Docker/getting-deep-on-orchestration-apis-actors-and-abstractions-in-a-distributed-system-by-jeff-nickoloff)
-- [runC: The little engine that could run Docker containers by Docker Captain Phil Estes, IBM] (http://www.slideshare.net/Docker/runc-the-little-engine-that-could-run-docker-containers-by-phil-estes)
-- [Unikernels and Docker: From Revolution to Evolution by Mindy Preston, Docker] (http://www.slideshare.net/Docker/unikernels-and-docker-from-revolution-to-evolution-unikernels-and-docker-from-revolution-to-evolution)
-- [Sharding Containers: Make Go Apps Computer-Friendly Again by Andrey Sibiryov, Uber] (http://www.slideshare.net/Docker/sharding-containers-make-go-apps-computerfriendly-again-by-andrey-sibiryov)
+- [The Golden Ticket: Docker and High Security Microservices by Aaron Grattafiori](http://www.slideshare.net/Docker/the-golden-ticket-docker-and-high-security-microservices-by-aaron-grattafiori)
+- [Cloning Running Servers with Docker and CRIU by Ross Boucher, Playground Theory](http://www.slideshare.net/Docker/cloning-running-servers-with-docker-and-criu-by-ross-boucher)
+- [Docker for Mac and Windows: The Insider’s Guide by Justin Cormack, Docker](http://www.slideshare.net/Docker/docker-for-mac-and-windows-the-insiders-guide-by-justin-cormack)
+- [Containerd: Building a Container Supervisor by Michael Crosby, Docker](http://www.slideshare.net/Docker/containerd-building-a-container-supervisor-by-michael-crosby)
+- [Windows Server and Docker – The Internals Behind Bringing Docker and Containers to Windows by Taylor Brown, Microsoft and John Starks, Microsoft](http://www.slideshare.net/Docker/windows-server-and-docker-the-internals-behind-bringing-docker-and-containers-to-windows-by-taylor-brown-and-john-starks)
+- [Getting Deep on Orchestration: APIs, Actors, and Abstractions in a Distributed System by Docker Captain Jeff Nickoloff, All in Geek Consulting](http://www.slideshare.net/Docker/getting-deep-on-orchestration-apis-actors-and-abstractions-in-a-distributed-system-by-jeff-nickoloff)
+- [runC: The little engine that could run Docker containers by Docker Captain Phil Estes, IBM](http://www.slideshare.net/Docker/runc-the-little-engine-that-could-run-docker-containers-by-phil-estes)
+- [Unikernels and Docker: From Revolution to Evolution by Mindy Preston, Docker](http://www.slideshare.net/Docker/unikernels-and-docker-from-revolution-to-evolution-unikernels-and-docker-from-revolution-to-evolution)
+- [Sharding Containers: Make Go Apps Computer-Friendly Again by Andrey Sibiryov, Uber](http://www.slideshare.net/Docker/sharding-containers-make-go-apps-computerfriendly-again-by-andrey-sibiryov)
 
-##Tracks: Use Case 
+##Tracks: Use Case
 
 ## Videos
 
-- [Learning the Alphabet: A/B, CD and [E-Z] in the Docker Datacenter by Brett Timperman, Kroger Technology] (https://youtu.be/sHS6jhXCwWM)
-- [Using the SDACK Architecture on Security Event Inspection by Evans Ye, Trend Micro and Yu-Lun Chen, Trend Micro] (https://youtu.be/j54VzJEwnck)
-- [Thinking Inside the Container: A Continuous Delivery Story by Maxfield Stewart, Riot Games] (https://youtu.be/YViFZBoKqjg)
-- [Use Docker to Deliver Cognitive Services Running Cross Platform and Multi Cloud Environments by Susan Diamond, IBM] (https://youtu.be/JNhacSo-0T0)
-- [Docker in Production, Look No Hands! by Docker Captain Scott Coulton, HealthDirect] (https://youtu.be/ePp54ofRqRs)
-- [Build Fast, Deploy Fast: Innovating in the Enterprise by Andy Lim and Imran Raja, GE] (https://youtu.be/vM0dUfnF-L4)
-- [Overseeing Ship’s Surveys and Surveyors Globally Using IoT and Docker by Jay Blanchard, Fugro Chance, Inc and Aater Suleman, Flux 7] (https://youtu.be/S7B-pEDoSeE)
-- [Securing the Container Pipeline at Salesforce by Cem Gürkök, Salesforce] (https://youtu.be/rxU1oz0HD0I)
-- [Fully Orchestrating Applications, Microservices and Enterprise Services with Docker at Société Générale by Cedric Coroir, Société Générale and Alex Drahon, Docker] (https://youtu.be/fd9yiUS6Sbw)
+- [Learning the Alphabet: A/B, CD and (E-Z) in the Docker Datacenter by Brett Timperman, Kroger Technology](https://youtu.be/sHS6jhXCwWM)
+- [Using the SDACK Architecture on Security Event Inspection by Evans Ye, Trend Micro and Yu-Lun Chen, Trend Micro](https://youtu.be/j54VzJEwnck)
+- [Thinking Inside the Container: A Continuous Delivery Story by Maxfield Stewart, Riot Games](https://youtu.be/YViFZBoKqjg)
+- [Use Docker to Deliver Cognitive Services Running Cross Platform and Multi Cloud Environments by Susan Diamond, IBM](https://youtu.be/JNhacSo-0T0)
+- [Docker in Production, Look No Hands! by Docker Captain Scott Coulton, HealthDirect](https://youtu.be/ePp54ofRqRs)
+- [Build Fast, Deploy Fast: Innovating in the Enterprise by Andy Lim and Imran Raja, GE](https://youtu.be/vM0dUfnF-L4)
+- [Overseeing Ship’s Surveys and Surveyors Globally Using IoT and Docker by Jay Blanchard, Fugro Chance, Inc and Aater Suleman, Flux 7](https://youtu.be/S7B-pEDoSeE)
+- [Securing the Container Pipeline at Salesforce by Cem Gürkök, Salesforce](https://youtu.be/rxU1oz0HD0I)
+- [Fully Orchestrating Applications, Microservices and Enterprise Services with Docker at Société Générale by Cedric Coroir, Société Générale and Alex Drahon, Docker](https://youtu.be/fd9yiUS6Sbw)
 
 ## Slides
 
-[Learning the Alphabet: A/B, CD and [E-Z] in the Docker Datacenter by Brett Timperman, Kroger Technology] (http://www.slideshare.net/Docker/learning-the-alphabet-ab-cd-and-ez-in-the-docker-datacenter-by-brett-timperman)
-- [Using the SDACK Architecture on Security Event Inspection by Evans Ye, Trend Micro and Yu-Lun Chen, Trend Micro] (http://www.slideshare.net/Docker/using-the-sdack-architecture-on-security-event-inspection-by-yulun-chen-and-evans-ye)
-- [Thinking Inside the Container: A Continuous Delivery Story by Maxfield Stewart, Riot Games] (http://www.slideshare.net/Docker/thinking-inside-the-container-a-continuous-delivery-story-by-maxfield-stewart)
-- [Use Docker to Deliver Cognitive Services Running Cross Platform and Multi Cloud Environments by Susan Diamond, IBM] (http://www.slideshare.net/Docker/use-docker-to-deliver-cognitive-services-running-cross-platform-and-multi-cloud-environments-by-susan-diamond-63917364)
-- [Docker in Production, Look No Hands! by Docker Captain Scott Coulton, HealthDirect] (http://www.slideshare.net/Docker/docker-in-production-look-no-hands-by-scott-coulton)
-- [Build Fast, Deploy Fast: Innovating in the Enterprise by Andy Lim and Imran Raja, GE] (http://www.slideshare.net/Docker/build-fast-deploy-fast-innovating-in-the-enterprise-by-imran-raja-and-andy-lim)
-- [Overseeing Ship’s Surveys and Surveyors Globally Using IoT and Docker by Jay Blanchard, Fugro Chance, Inc and Aater Suleman, Flux 7] (http://www.slideshare.net/Docker/overseeing-ships-surveys-and-surveyors-globally-using-iot-and-docker-by-jay-blanchard-and-aater-suleman)
-- [Securing the Container Pipeline at Salesforce by Cem Gürkök, Salesforce] (http://www.slideshare.net/Docker/securing-the-container-pipeline-at-salesforce-by-cem-gurkok-63493231)
-- [Fully Orchestrating Applications, Microservices and Enterprise Services with Docker at Société Générale by Cedric Coroir, Société Générale and Alex Drahon, Docker] (http://www.slideshare.net/Docker/fully-orchestrating-applications-microservices-and-enterprise-services-with-docker-at-societe-generale-by-cedric-coroir-and-alex-drahon)
+[Learning the Alphabet: A/B, CD and (E-Z) in the Docker Datacenter by Brett Timperman, Kroger Technology](http://www.slideshare.net/Docker/learning-the-alphabet-ab-cd-and-ez-in-the-docker-datacenter-by-brett-timperman)
+- [Using the SDACK Architecture on Security Event Inspection by Evans Ye, Trend Micro and Yu-Lun Chen, Trend Micro](http://www.slideshare.net/Docker/using-the-sdack-architecture-on-security-event-inspection-by-yulun-chen-and-evans-ye)
+- [Thinking Inside the Container: A Continuous Delivery Story by Maxfield Stewart, Riot Games](http://www.slideshare.net/Docker/thinking-inside-the-container-a-continuous-delivery-story-by-maxfield-stewart)
+- [Use Docker to Deliver Cognitive Services Running Cross Platform and Multi Cloud Environments by Susan Diamond, IBM](http://www.slideshare.net/Docker/use-docker-to-deliver-cognitive-services-running-cross-platform-and-multi-cloud-environments-by-susan-diamond-63917364)
+- [Docker in Production, Look No Hands! by Docker Captain Scott Coulton, HealthDirect](http://www.slideshare.net/Docker/docker-in-production-look-no-hands-by-scott-coulton)
+- [Build Fast, Deploy Fast: Innovating in the Enterprise by Andy Lim and Imran Raja, GE](http://www.slideshare.net/Docker/build-fast-deploy-fast-innovating-in-the-enterprise-by-imran-raja-and-andy-lim)
+- [Overseeing Ship’s Surveys and Surveyors Globally Using IoT and Docker by Jay Blanchard, Fugro Chance, Inc and Aater Suleman, Flux 7](http://www.slideshare.net/Docker/overseeing-ships-surveys-and-surveyors-globally-using-iot-and-docker-by-jay-blanchard-and-aater-suleman)
+- [Securing the Container Pipeline at Salesforce by Cem Gürkök, Salesforce](http://www.slideshare.net/Docker/securing-the-container-pipeline-at-salesforce-by-cem-gurkok-63493231)
+- [Fully Orchestrating Applications, Microservices and Enterprise Services with Docker at Société Générale by Cedric Coroir, Société Générale and Alex Drahon, Docker](http://www.slideshare.net/Docker/fully-orchestrating-applications-microservices-and-enterprise-services-with-docker-at-societe-generale-by-cedric-coroir-and-alex-drahon)

--- a/Docker-Meetup-Content/DockerCon EU 2015.md
+++ b/Docker-Meetup-Content/DockerCon EU 2015.md
@@ -5,19 +5,19 @@
 **General Session**
 
 - [Getting started with Docker Toolbox and Compose](http://blog.docker.com/2015/11/docker-toolbox-compose/)
-  
+
   Docker Toolbox reached full Mac/Windows feature parity, this is a big milestone. See [DockerCon EU Demo on youtube](https://www.youtube.com/watch?v=fLfFFtOHRZQ&feature=youtu.be&t=3898)
 - [Docker Content Trust gets hardware signing with YubiKey](https://blog.docker.com/2015/11/docker-content-trust-yubikey/)
-  
+
   Docker Content Trust, announced at DockerCon in August, now supports hardware based signing. See [DockerCon EU Demo on youtube of how this works](https://youtu.be/fLfFFtOHRZQ?t=4881)
-- Container security: Project Nautilus revealed to public. 
-  
+- Container security: Project Nautilus revealed to public.
+
   Built-in Container Security analysis in Docker Hub, went live 2 months ago & Self-service coming soon. [See full details from Keynote on youtube](https://youtu.be/fLfFFtOHRZQ?t=6015)
 - Swarm Volume API support.
-  
+
   Control life-cycle of data as well as life-cycle of containers. [See full details from Keynote on youtube](https://youtu.be/fLfFFtOHRZQ?t=6690)
 - [Scale testing Docker Swarm to 30.000 containers](https://blog.docker.com/2015/11/scale-testing-docker-swarm-30000-containers/)
- 
+
   swarm was announced as production ready, but does it scale? [DockerCon EU Demo on youtube](https://youtu.be/fLfFFtOHRZQ?t=6760)
 
 **Slides from Day 1 Sessions**
@@ -52,12 +52,15 @@
 
 | Black Belt Tech | Docker Docker Docker | Wild Cards | Use Case | Eco System | Contribute & Collaborate |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| ["How to be successful running Docker in Production"](http://www.slideshare.net/Docker/how-to-be-successful-running-docker-in-production) [@johnfiedler](https://twitter.com/JohnFiedler) [video](https://youtu.be/j6Ge4wP1yH0) | ["Docker Universal Control Plane"](http://www.slideshare.net/Docker/gordons-special-session-docker-universal-control-plane) | ["Cultural Revolution - How to Manage the Changes Docker Brings"](http://www.slideshare.net/Docker/cultural-revolution-how-to-mange-the-change-docker-brings) [video](https://youtu.be/-qHwL8C9UoA) - [Insights](https://zwischenzugs.wordpress.com/2015/11/17/dockerconeu-2015-talk-you-know-more-than-you-think/) | ["Trading Bitcoin with Docker"](http://www.slideshare.net/Docker/trading-bitcoin-with-docker) [video](https://youtu.be/2ZbnWoiARf4) | ["Production-Ready Containers from IBM and Docker"](http://www.slideshare.net/Docker/production-ready-containers-from-ibm-and-docker), ["Multi-arch Registry Support"](http://www.slideshare.net/PhilEstes/2015-dockercon-lightning-talk-multiarch-registry-support) | "Meet the Docker Maintainers: Engine, Networking, Swarm, Distribution" |
-| "Green Font, Black Background - Docker Security by Example" [@nathanmccauley](https://twitter.com/nathanmccauley), [@diogomonica](https://twitter.com/diogomonica) No slides, 100% shell [video](https://youtu.be/blNIreAq6hc) | ["Deploying and Managing Containers for Developers"](http://www.slideshare.net/Docker/deploying-and-managing-containers-for-developers) by Tutum | ["Docker Monitoring"](http://www.slideshare.net/Docker/docker-monitoring-55436594), ["Docker Monitoring with DataDog"](http://www.slideshare.net/Docker/monitoring-docker) [video](https://youtu.be/sxE1vDtkYps)| ["Continuous Integration with Jenkins, Docker and Compose"](http://www.slideshare.net/Docker/continuous-integration-with-jenkins-docker-and-compose) [video](https://youtu.be/cvmiM0_3NhA) |  |  |
-| ["Windows Server Containers - how we got here and architecture deep dive"](http://www.slideshare.net/Docker/windows-server-containers-how-we-hot-here-and-architecture-deep-dive) [@icecrime](https://twitter.com/icecrime) [video](https://youtu.be/GCRbH4aa7VI) | ["What's New in Docker Trusted Registry"](http://www.slideshare.net/Docker/whats-new-with-docker-trusted-registry) | ["Persistent, 'stateful' services with docker clusters"](http://www.slideshare.net/Docker/persistent-stateful-services-with-docker-cluster-namespaces-and-docker-volume-magic) [video](https://youtu.be/e1yXmc7-mU4) | ["The Glue is the Hard Part: Making a Production-Ready PaaS"](http://www.slideshare.net/Docker/the-glue-is-the-hard-part-making-a-productionready-paas) [video](https://youtu.be/VXLn7RpzUpc) | "Lightning talks: Global Hack Day #3 - Top 3 Winning Hacks": ScaleSwarm, ["Container Migration Tool"](http://www.slideshare.net/Docker/container-migration-tool) & On-Demand YARN clusters | "Docker Universal Control Plane Hands-on Test Drive" |
-| ["Container torture: run any binary in any running container. 0 patch"](http://www.slideshare.net/Docker/container-torture-run-any-binary-in-any-container) [@oyadutaf](http://twitter.com/oyadutaf) [video](https://youtu.be/lYf0dBia9Fs) | ["Official Repos and Project Nautilus"](http://www.slideshare.net/Docker/official-repos-and-project-nautilus) | ["The missing Piece: when Docker networking and services finally unleaches software architecture 2.0"](http://www.slideshare.net/Docker/the-missing-piece-when-docker-networking-unleashing-soft-architecture-v15) [video](https://youtu.be/wLTDn3uNd4c) | ["It's in the game: the path to micro-services at Electronic Arts with Docker"](http://www.slideshare.net/Docker/its-in-the-game-the-path-to-microservices-at-electronic-arts-with-docker) & @ [Riot Gaming](http://engineering.riotgames.com/news/jenkins-docker-proxies-and-compose) [video](https://youtu.be/WyPoWsE--Yg) | "Lightning talks: [ING](http://www.slideshare.net/Docker/full-stack-testing-using-docker-compose-and-gradle), [Accenture](http://www.slideshare.net/Docker/continuous-delivery-live), [Apcera](http://www.slideshare.net/Docker/authentication-and-policy-enforcement-for-docker)" | "Meet the Docker Maintainers: Machine, Kitematic, Compose" |
+["How to be successful running Docker in Production"](http://www.slideshare.net/Docker/how-to-be-successful-running-docker-in-production) [@johnfiedler](https://twitter.com/JohnFiedler) [video](https://youtu.be/j6Ge4wP1yH0) | ["Docker Universal Control Plane"](http://www.slideshare.net/Docker/gordons-special-session-docker-universal-control-plane) | ["Cultural Revolution - How to Manage the Changes Docker Brings"](http://www.slideshare.net/Docker/cultural-revolution-how-to-mange-the-change-docker-brings) [video](https://youtu.be/-qHwL8C9UoA) - [Insights](https://zwischenzugs.wordpress.com/2015/11/17/dockerconeu-2015-talk-you-know-more-than-you-think/) | ["Trading Bitcoin with Docker"](http://www.slideshare.net/Docker/trading-bitcoin-with-docker) [video](https://youtu.be/2ZbnWoiARf4) | ["Production-Ready Containers from IBM and Docker"](http://www.slideshare.net/Docker/production-ready-containers-from-ibm-and-docker), ["Multi-arch Registry Support"](http://www.slideshare.net/PhilEstes/2015-dockercon-lightning-talk-multiarch-registry-support) | "Meet the Docker Maintainers: Engine, Networking, Swarm, Distribution" |
 
-## Youtube
+"Green Font, Black Background - Docker Security by Example" [@nathanmccauley](https://twitter.com/nathanmccauley), [@diogomonica](https://twitter.com/diogomonica) No slides, 100% shell [video](https://youtu.be/blNIreAq6hc) | ["Deploying and Managing Containers for Developers"](http://www.slideshare.net/Docker/deploying-and-managing-containers-for-developers) by Tutum | ["Docker Monitoring"](http://www.slideshare.net/Docker/docker-monitoring-55436594), ["Docker Monitoring with DataDog"](http://www.slideshare.net/Docker/monitoring-docker) [video](https://youtu.be/sxE1vDtkYps)| ["Continuous Integration with Jenkins, Docker and Compose"](http://www.slideshare.net/Docker/continuous-integration-with-jenkins-docker-and-compose) [video](https://youtu.be/cvmiM0_3NhA) |  |  |
+
+["Windows Server Containers - how we got here and architecture deep dive"](http://www.slideshare.net/Docker/windows-server-containers-how-we-hot-here-and-architecture-deep-dive) [@icecrime](https://twitter.com/icecrime) [video](https://youtu.be/GCRbH4aa7VI) | ["What's New in Docker Trusted Registry"](http://www.slideshare.net/Docker/whats-new-with-docker-trusted-registry) | ["Persistent, 'stateful' services with docker clusters"](http://www.slideshare.net/Docker/persistent-stateful-services-with-docker-cluster-namespaces-and-docker-volume-magic) [video](https://youtu.be/e1yXmc7-mU4) | ["The Glue is the Hard Part: Making a Production-Ready PaaS"](http://www.slideshare.net/Docker/the-glue-is-the-hard-part-making-a-productionready-paas) [video](https://youtu.be/VXLn7RpzUpc) | "Lightning talks: Global Hack Day #3 - Top 3 Winning Hacks": ScaleSwarm, ["Container Migration Tool"](http://www.slideshare.net/Docker/container-migration-tool) & On-Demand YARN clusters | "Docker Universal Control Plane Hands-on Test Drive"
+
+["Container torture: run any binary in any running container. 0 patch"](http://www.slideshare.net/Docker/container-torture-run-any-binary-in-any-container) [@oyadutaf](http://twitter.com/oyadutaf) [video](https://youtu.be/lYf0dBia9Fs) | ["Official Repos and Project Nautilus"](http://www.slideshare.net/Docker/official-repos-and-project-nautilus) | ["The missing Piece: when Docker networking and services finally unleaches software architecture 2.0"](http://www.slideshare.net/Docker/the-missing-piece-when-docker-networking-unleashing-soft-architecture-v15) [video](https://youtu.be/wLTDn3uNd4c) | ["It's in the game: the path to micro-services at Electronic Arts with Docker"](http://www.slideshare.net/Docker/its-in-the-game-the-path-to-microservices-at-electronic-arts-with-docker) & @ [Riot Gaming](http://engineering.riotgames.com/news/jenkins-docker-proxies-and-compose) [video](https://youtu.be/WyPoWsE--Yg) | "Lightning talks: [ING](http://www.slideshare.net/Docker/full-stack-testing-using-docker-compose-and-gradle), [Accenture](http://www.slideshare.net/Docker/continuous-delivery-live), [Apcera](http://www.slideshare.net/Docker/authentication-and-policy-enforcement-for-docker)" | "Meet the Docker Maintainers: Machine, Kitematic, Compose"
+
+## YouTube
 - Day 1 General section: https://www.youtube.com/watch?v=fLfFFtOHRZQ
 - Day 2 General section: https://www.youtube.com/watch?v=i8YM4bkpR-E
 - Day 2 Closing general section: https://www.youtube.com/watch?v=ZBcMy-_xuYk
@@ -73,7 +76,7 @@ The complete set of Docker Hands On Labs can be found [here](https://github.com/
 * Docker Content Trust
 * Docker Networking
 * Understanding Docker Volumes
-* Continuous Integration and Continious Delivery(CICD) with Docker, GitHub, and Jenkins
+* Continuous Integration and Continuous Delivery (CI/CD) with Docker, GitHub, and Jenkins
 * Automated Builds with Docker Hub and GitHub
 
 
@@ -96,4 +99,3 @@ The complete set of Docker Hands On Labs can be found [here](https://github.com/
 - Embedded Linux - [Yocto](https://www.yoctoproject.org/), used by Resin.io
 
 ** [Twitter Stream](https://twitter.com/search?q=%40dockercon%20OR%20%23dockercon) **
-

--- a/Organizers/Resources/Docker Meetup Guide.md
+++ b/Organizers/Resources/Docker Meetup Guide.md
@@ -2,18 +2,18 @@
 
 Docker Meetups are social events organized by community members who are interested in talking and learning about the Docker projects.
 
-Anyone who is interested in meeting with others to discuss about Docker is welcome to organize meetups. We simply ask our organizers to comply with our Code of Conduct and ensure everyone in the community feels welcome!
+Anyone who is interested in meeting with others to discuss about Docker is welcome to organize meetups. We simply ask our organizers to comply with our [Code of Conduct](https://github.com/docker/code-of-conduct) and ensure everyone in the community feels welcome!
 
-This guide helps you to successfully organize Docker Meetups. It provides tips, checklists and concepts to do your planning effectively.
+This guide helps you to successfully organize Docker Meetups. It provides tips, checklists, and concepts to do your planning effectively.
 
 
 # Preparation
 At first, make sure you answer the following questions:
 
   - **Bootstrap or contribute:** Anyone can start a Docker Meetup group as long as there is not an existing Docker user group in your city. Check out the [Docker community page](https://www.docker.com/community/meetup-groups) to make sure a group does not already exist in your region.
-  - **Team up – but stay with a single coordinator.**
-  In case do opt for bootstrapping the meetup, try go get others involved. Spread the tasks across several shoulders, but make sure there is a single responsible who manages all important information.
-  - **Check: Commitment**: Ask yourself: In case the first meetup works out well, will you take enough time to organize a second and a third one? It's not worth it for just a single one. Organizing meetups is very rewarding in several aspects, but it's organize within a fingers snap.
+  - **Team up – but maintain a single coordinator**
+  In case you opt for bootstrapping the meetup, try go get others involved. Spread the tasks across several shoulders, but make sure there is a single person responsible who manages all important information.
+  - **Check: Commitment**: Ask yourself: In case the first meetup works out well, will you take enough time to organize a second and a third one? It's not worth it for just a single one. Organizing meetups is very rewarding in several aspects but building and maintaining a community requires a commitment.
 
 
 # Structure Your Meetup Project
@@ -22,18 +22,18 @@ Once the group is launched, we recommend scheduling the first meetup with enough
 
 Next, make yourself familiar with the three most relevant tools:
   - Mobilize.com: It provides updates from Docker and the Community
-  - Github.com: You wanna document here everything you do, e.g. TODO lists
+  - Github.com: Create TODO lists, agendas, and meeting notes
   - Meetup.com: Publish events and track attendees
 
-As a red thread through the organizing process, you can use the following phases to structure your planning:
+As you go through the organizing process, you can use the following phases to structure your planning for a successful meeting:
 
 ![](Images_for_meetup_guide/Project_Phases.png)
 
-Start with a scoping phase that shapes the general purpose of your meetup series. In this phase, you answer questions like: Do I want to organize simple, open discussions about Docker or I want to invite speakers. All the remaining phases belong to a single meetup, i.e. for each meetup you start with planning and finish up with the closing phase. Following this red thread will make it easy for you to always have an overview what's important now and next.
+Start with a scoping phase that shapes the general purpose of your meetup series. In this phase, you answer questions like: Do I want to organize simple, open discussions about Docker or I want to invite speakers? All the remaining phases belong to a single meetup, i.e. for each meetup you start with planning and finish up with the closing phase. Following this guide will make it easy for you to always have an overview what's important now and next.
 
 ## Scope
-  - **Define your scope and goal:** All subsequent planning steps are aligned to the scope and goal you define. Deine, what kind of meetup you wanna run:
-  Usually, Docker Meetup events are 2-3 hours long, start between 4pm and 7pm and feature 1 to 3 main talks lasting 20-30 minutes each. The agenda is up to each meetup Community, so feel free to mix or exchange this with e.g.
+  - **Define your scope and goal:** All subsequent planning steps are aligned to the scope and goal you define. Define, what kind of meetup you want to run:
+  Usually, Docker Meetup events are 2-3 hours long, start between 4pm and 7pm and feature 1 to 3 main talks lasting 20-30 minutes each. The agenda is up to each meetup Community, so feel free to explore different avenues to share knowledge:
    - Simple social gatherings to discuss Docker projects
    - 10-minute lightning talks
    - Docker Training
@@ -41,7 +41,7 @@ Start with a scoping phase that shapes the general purpose of your meetup series
    - Panels
    - Presenting use cases
    - Advanced technical deep dives
-  - **Target Group**: Advertisement for Students is very much different than it is for employees. Define your target group to allocate appropriate ad resources later on.
+  - **Target Group**: Advertising for students is very different than it is for employees. Define your target group to allocate appropriate ad resources later on.
   - **Frequency:**: Having a regular meetup date is key to an active group. Consistent meetups are essential in building a thriving community. Is there a certain time that works best for everyone? How often will you meet? No matter what your group decides, allowing enough time to travel to the meetup location and holding frequent, regular meetup events are two significant catalysts for a strong and active meetup group.
 
 
@@ -51,7 +51,7 @@ This planning document should gather all relevant information for the particular
 
 <img src="Images_for_meetup_guide/Planning_Categories_Tasks.png" width="600">
 
-Each category contains a set of associated tasks. Thereby, each tasks ideally has
+Each category contains a set of associated tasks. Thereby, each tasks ideally has:
 - a checkbox to track the progress
 - the name of the one who is responsible for the tasks
 - a deadline, if appropriate
@@ -68,8 +68,8 @@ Next, see the following tips for each category:
 
 
   - **Advertisement**:
-  General advice: Try and error, after the third meetup you'll have a good feeling of which ad is useful or not.
-  Indoor, doors that are often used is very recommended, such as entrances to cafeterias in your company or at university.
+  General advice: Trial and error. After the third meetup you'll have a good feeling of which ad is useful or not.
+  Indoor, locations that are often used is highly recommended, such as entrances to cafeterias in your company or at university.
 
   You can help with promoting your event across Docker’s social media channels. Once your meetup page is created, we’ll add your group to the global map and include it in our meetup groups.
 
@@ -79,33 +79,33 @@ Next, see the following tips for each category:
 
   Join forces! You may consider joining forces with another complementary meetup group with shared interests and goals. For new groups - perhaps in more remote locations - cross-promotion can be a great way to kick start and establish the group’s presence. You can create an event together and then share it with each group’s members to multiply attendance. This encourages and builds the community on both sides.
 
-  In all advertisements, you wanna reference to the meetup.com event page. Changing details on meetup.com is way easier than on all already published ads.
+  In all advertisements, you should reference the meetup.com event page. Changing details on meetup.com is much easier than on physically published ad.
 
-  For more advice on how to promote your meetup, check out the official meetup.com promotion page.
+  For more advice on how to promote your meetup, check out [promote my meetup group on Meetup](https://www.meetup.com/help/topics/45/article/865489/).
 
   - **Sponsorship**
   The main benefit of sponsoring a Docker Meetup is visibility. As a sponsor, you can gain visibility in the following ways:
 
-    - Giving a regular talk at the meetup or a short introduction talk (2-5 Min.) at the beginning, as long it is not a sales pitch!
+    - Giving a regular talk at the meetup or a short introduction talk (2-5 min) at the beginning (as long it is not a sales pitch!)
     - Listing as a sponsor on the meetup.com page left column
     - Listing in the meetup event page event details
     - Thanks in pre- and/or post-event emails
     - Verbal thank you in opening or closing remarks
     - Recognition in the following Docker promotional channels
-    - Docker social media networks
-    - Docker Weekly newsletter
-    - Docker Monthly Events blog
+      * Docker social media networks
+      * Docker Weekly newsletter
+      * Docker Monthly Events blog
 
   There are three sponsorship options available:
 
-    -Venue Host sponsorship
-    -Food/ Beverage sponsorship
-    -Venue + Food/ Beverage sponsorship
+    - Venue Host sponsorship
+    - Food/Beverage sponsorship
+    - Venue + Food/Beverage sponsorship
 
-  In an effort to keep our meetup events neutral, we mostly welcome ad hoc sponsorships. If you are interested in a recurring sponsorship, please contact Docker at meetups@docker.com
+  In an effort to keep our meetup events neutral, we mostly welcome ad hoc sponsorships. If you are interested in a recurring sponsorship, please contact Docker at meetups@docker.com.
 
   - **Venue**:
-  Organizing a Venue might take some time. Make sure this is one of the tasks you allocate resources to early.
+  Organizing a venue might take some time. Make sure this is one of the tasks you allocate resources to early.
   Message members in the group to see if they know of any companies that might be willing to offer office space for the meetup. Since meetups occur after traditional business hours, this request should not interfere with business activities.
   Research where other local developer groups (such as Python, Ruby or Golang user Groups) hold meetups.
   Reach out to companies in the Docker ecosystem that have offices in your local area.
@@ -115,30 +115,31 @@ Next, see the following tips for each category:
 
   The building should also be handicap accessible.
 
-  Consider to send your phone number to all attendees 2-3 days before the meetup, or get a cheap SIM card and burning phone for this purpose.
+  Consider sending your phone number to all attendees 2-3 days before the meetup, or get a cheap SIM card and burner phone for this purpose.
 
   Consider the size of the room and design. Does it complement the format of event you want to host? Is there an adequate number of chairs? A room can also be too big. If you only expect 20 people, avoid booking a room that can hold 100 as it will feel empty.
 
   Does the building have security? If so, what is the check in procedure? What information do they require in advance?
   Is the hosting venue willing to sponsor food and beverage? It's also a great help if they can coordinate ordering and deliveries, but always offer to assist since they are already being gracious.
+
   What audio/visual equipment is available at the venue? Do they have a microphone, projector/Apple TV available for presentations?
 
   When in doubt, feel free to reach out to Victor Coisne (victor@docker.com)
 
   - **Equipment:**
-  Make sure you'll have presentation tools at the venue incl. a beamer, presenter, and AV if necessary.
-  Consider to provide small gifts to the speaker. Sometimes, speaker have come a very long way. A small gift compensates for that. Just the same as important: It also motivates the speaker to come again, and it motivates others to give talks!
+  Make sure you'll have presentation tools at the venue including a beamer, presenter, and AV if necessary.
+  Consider providing small gifts to the speaker. Sometimes, speaker have come a very long way. A small gift compensates for that. Just as important: It also motivates the speaker to come again, and it motivates others to give talks!
   Ask Docker for swags: Get giveaways as e.g. stickers from Docker, the sponsors and the venue if applicable. This gives attendees a feeling it was even more worth to come in person.  
 
   - **Speakers:**
   In general, good speakers are rare, often busy themselves, but important for a good meetup series.
-  Even if the speaker's content seems very well, some speakers cannot properly deliver their content. But precheck is hard. Therefore, try to see the speaker once in advance, e.g. on other meetups.
+  Even if the speaker's content seems very good, some speakers cannot properly deliver their content. Try to see the speaker once in advance, e.g. on other meetups or do a dry-run with them.
 
   Message members in the group to see if they would like to present or if they know of any speakers from their network.
   Is there anyone from the Docker Team in the local area who could give a talk?
-  Find local developer conferences, review the speaker list, and identify if anyone could be using Docker. Conferences can be tracked on lanyrd.com.
+  Find local developer conferences, review the speaker list, and identify if anyone could be using Docker. Conferences can be tracked on [lanyrd.com](lanyrd.com).
   If members feel that a full presentation with slides is too much of a time commitment, a shorter lightning talk of 5-10 minutes or a quick demo is also great! Everyone can learn something from each other.
-  Tip in selecting appropriate speakers: talks should not be a sales pitch, but can however showcase a company’s tech and how it uses Docker. We also don’t expect speakers to “oversell” Docker. They should “be themselves” and formulate a talk they feel would be relevant to Docker users.
+  Tips for selecting appropriate speakers: talks should not be a sales pitch, but can however showcase a company’s tech and how it uses Docker. We also don’t expect speakers to “oversell” Docker. They should “be themselves” and formulate a talk they feel would be relevant to Docker users.
 
   Have a moderator (can by anyone who feels good in doing this) that leads through the talks. Start with a warm welcome, announce each talk and wish everyone a good safe home. It's that easy.
 
@@ -165,7 +166,7 @@ Next, see the following tips for each category:
 
   Are there any venue-specific instructions attendees should know? Add some helpful tips about the meeting location and what to do once there, so getting to the meetup is as easy as possible.
 
-  Here is a [good example of a good meetup description] (http://www.meetup.com/Docker-meetups/events/226172627/) you may want to use as a starting template. Also see the following one as an example:
+  Here is a [good example of a good meetup description](http://www.meetup.com/Docker-meetups/events/226172627/) you may want to use as a starting template. Also see the following one as an example:
 
   <img src="Images_for_meetup_guide/Timetable_Agenda.png" width="600">
 
@@ -177,7 +178,7 @@ Next, see the following tips for each category:
 
   Consider food that is easy to eat and require minimal utensil usage. You want attendees to network and socialize easily without worrying about how to eat their food. Most groups opt for pizza, but variety is appreciated. They also don’t want to make a mess and you probably don’t want to stay late cleaning up after them. It’s also a good idea to provide options for those with different diets, such as: vegetarian, vegan, gluten-free, Kosher, etc. No hungry engineers here!
 
-  Regarding the drinks: Many groups choose to offer alcohol, while many others choose not to - it is up to you. Be sure to follow and respect the venue’s rules around alcohol consumption on their premises - you want to be invited back! Provide drink alternatives, including and especially water. Don’t forget to watch out for the openly inebriated! You want your members to feel safe and return without the memory of a bad experience.
+  Regarding the drinks: Many groups choose to offer alcohol, while many others choose not to - it is up to you. Be sure to follow and respect the venue’s rules around alcohol consumption on their premises - you want to be invited back! Provide non-alcohol alternatives such as soda and water. Don’t forget to watch out for the openly inebriated! You want your members to feel safe and return without the memory of a bad experience.
 
   If your group is able to secure a sponsorship, be sure to list the sponsor in the event announcement and thank them before presentations. Let your group know if food and drinks will be provided so attendees can plan their meals ahead of time.
 
@@ -191,23 +192,23 @@ Next, see the following tips for each category:
 ## Kick-Off Preparations
 In this phase you basically start to do what you planned, e.g. buy equipment, drinks, cups, etc.
 
-Visit the venue and think about directions you need to provide, get in touch with responsibles of the venue.
+Visit the venue and think about directions you need to provide, get in touch with responsible of the venue.
 
 Check the presentation equipment.
 
 ...
 
 ## Lauch: Meet up!
-Plan to be finished 15 Min. before the meetup officially starts. You'll need this buffer anyway :-)
+Plan to be finished 15 minutes before the meetup officially starts. You'll need this buffer anyway :-)
 Let the moderator start starting the show, e.g. by asking the crowd where they come from etc.
 Manage the speakers' time by two simple methods:
-  - During his talk, sit in the first row. 5 Min. before the speaker's time is over, stand up and move to the front in a way that you don't disturb the talk, but the speaker recognizes you.
+  - During his talk, sit in the first row. Five minutes before the speaker's time is over, stand up and move to the front in a way that you don't disturb the talk, but the speaker recognizes you.
   - Move closer to the speaker the more he is overdue.
 
 ##  Closing
 This phase is all about getting feedback. Really good feedback requires asking for it. Use offline and online channels to do so.
 
-With your co-organizers, rethink the event and gather ideas to improve.
+With your co-organizers, discuss the event and gather ideas to improve.
 
 Document all your feedback and ideas for next time.
 
@@ -218,24 +219,24 @@ If applicable, write a blog post about the meetup with pictures and its highligh
 
 # Online Resources available to Meetup organizers
 
-#### [Mobilize] (https://docker.mobilize.io)
+#### [Mobilize](https://docker.mobilize.io)
 Mobilize is a simple communication & directory tool for us to share events, activities, and programs with groups of active community members. All our members can easily reach one another. You can open discussions among selected members, send direct messages, share ideas and experiences, get help finding sponsors and speakers and help other members succeed and run great meetup events. When the community supports each other, everyone wins!
 The Docker Community page.
 
-#### [Docker Blog] (https://blog.docker.com/)
-The Docker Blog is a great resource to find content! We post the latest Docker news including new releases and events like DockerCon there. For our curated collection of content from the community, check out this page: http://www.scoop.it/t/docker-by-docker
+#### [Docker Blog](https://blog.docker.com/)
+The Docker Blog is a great resource to find content! We post the latest Docker news including new releases and events like DockerCon there. For our curated collection of content from the community, check out this page: http://www.scoop.it/t/docker-by-docker.
 
 ####[Docker Weekly](https://www.docker.com/newsletter-subscription)
 Get the latest Docker news straight to your inbox! This weekly newsletter highlights content from the community along with the latest Docker news.
 
-#### [Docker Docs] (https://docs.docker.com/)
+#### [Docker Docs](https://docs.docker.com/)
 Get all the info on the different Docker projects with our docs.
 
-#### [Slideshare] (http://www.slideshare.net/docker)
+#### [Slideshare](http://www.slideshare.net/docker)
 Another great resource for finding content! Docker’s Slideshare account has slide decks from Docker presentations - you’re welcome to use and/or modify these slides when presenting to your own meetup group.
 
-#### [Youtube] (https://www.youtube.com/user/dockerrun)
+#### [YouTube](https://www.youtube.com/user/dockerrun)
 Check out our YouTube page for videos of recorded talks from DockerCon, webinars and other meetups.
 
 #### Social Media
-Follow us on [Twitter] (https://twitter.com/docker), join the Docker community on [Google+](https://plus.google.com/u/0/communities/108146856671494713993), like Docker on [Facebook](https://www.facebook.com/docker.run) and join the Docker Users Group on [LinkedIn] (https://www.linkedin.com/company/docker)
+Follow us on [Twitter](https://twitter.com/docker), join the Docker community on [Google+](https://plus.google.com/u/0/communities/108146856671494713993), like Docker on [Facebook](https://www.facebook.com/docker.run) and join the Docker Users Group on [LinkedIn](https://www.linkedin.com/company/docker)

--- a/Organizers/Resources/Docker meetup FAQ.md
+++ b/Organizers/Resources/Docker meetup FAQ.md
@@ -1,9 +1,9 @@
 # Ready to start your own Docker Meetup Group?
 Docker Meetups are social events organized by community members who are interested in talking and learning about the Docker Open Source Projects. Anyone can start a Docker Meetup group as long as there isn’t already a Docker meetup group in your city. We simply ask our organizers to comply with our Code of Conduct and work with them to ensure everyone in the community is feeling welcome!
-Interested in launching a Docker Meetup Group ?
+Interested in launching a Docker Meetup Group?
 Fill out [this form](https://docker.mobilize.io/entities/2371/registrations) to get started and have our team reach out and create the user group on meetup.com! Our community team would be happy to work with you on solving some of the challenges associated with organizing meetups in your area.
 
-# What are the best practices for launching a Meetup Group ?
+# What are the best practices for launching a Meetup Group?
 Attend similar Meetups to gain experience and gauge interest in Docker.
 Contact people interested in Docker to help organize and promote.
 Research companies in your area willing to host an event.
@@ -11,16 +11,16 @@ Check out the calendar to find dates that don’t compete with other events.
 Understand what topics interest your local audience
 Pay attention to the Meetup page aesthetics, add logos and pictures, invite members to leave comments and reply to these comments
 Promote the event on social media and invite your peers
- 
+
 
 # How does Docker, Inc support Docker Meetup organizers?
 We send you some cool SWAG (t-shirts, stickers, etc)
 We promote every Meetup on Docker.com, the Docker Weekly newsletter and Social Media
 We help schedule speaking engagement from Docker employees and community members
 We Connect you with other organizers, local users and companies willing to host or sponsor meetups in your area.
- 
 
-# Are there any benefits associated with being a Docker meetup organizer ?
+
+# Are there any benefits associated with being a Docker meetup organizer?
 We see meetup organizers as members of the Docker family. Although there are no direct compensation associated with being a meetup organizers given the open source nature of the project, we often reward meetup organizer with free or discounted tickets to DockerCon, special swags, or treat you to a nice lunch (or a few beers) when you pay us a visit at Docker HQ.
 
 # How many attendees usually attend Docker Meetups?
@@ -36,7 +36,7 @@ Send an email to the docker-users mailing list including the link to your new Me
 Look for a company willing to provide the venue for the meetup
 Find a date for the first meetup that does not compete with other groups
 Look for potential speakers living in your city
- 
+
 # Am I allowed to use the Docker logo ?
 You are allowed to use the Docker logo on the meetup group page as long as you respect our [code of conduct](https://github.com/docker/code-of-conduct). Check out our media kit to choose which versions of the Docker logo you’d like to use.
 
@@ -48,7 +48,7 @@ Looking for more information on how to start and grow a Docker Meetup group? Con
 We are always looking for new office space to host Docker Meetups or new companies to sponsor food, drinks, swag or video recording. If your company is willing to sponsor a local Docker Meetup Group, please fill out [this form](https://docker.mobilize.io/entities/2371/registrations) or contact the local organizers directly via meetup.com
 
 # Who should I contact if I or one my colleague wants to give a talk at a meetup?
-Please fill out [this form](https://docker.mobilize.io/entities/2371/registrations) to get started and have our team reach out or contact the local organizers directly via meetup.com
+Please fill out [this form](https://docker.mobilize.io/entities/2371/registrations) to get started and have our team reach out or contact the local organizers directly via meetup.com.
 
 # Where can I find slide template for my talks?
-Check out the files section of the organizer group in Mobilize
+Check out the files section of the organizer group in Mobilize.

--- a/Organizers/Resources/sponsorship guidelines.md
+++ b/Organizers/Resources/sponsorship guidelines.md
@@ -1,51 +1,51 @@
 # Docker Meetup Sponsorship Guidelines
 
-## Why sponsor? 
+## Why sponsor?
 
 The main benefit of sponsoring a Docker Meetup is visibility. As a sponsor, you can gain visibility in the following ways:
 - Listing as a sponsor on the meetup.com page left column
 - Listing in the meetup event page event details
-- Thanks in pre- and/or post-event emails 
-- Verbal thank you in opening or closing remarks 
-- Recognition in the following Docker promotional channels 
-- Docker social media networks 
+- Thanks in pre- and/or post-event emails
+- Verbal thank you in opening or closing remarks
+- Recognition in the following Docker promotional channels
+- Docker social media networks
 - Docker Weekly newsletter
 - Docker Monthly Events blog
-		
+
 There are three sponsorship options available:
 - Venue Host sponsorship
 - Food/ Beverage sponsorship
 - Venue + Food/ Beverage sponsorship
 
-Thank you to all our wonderful sponsors! 
+Thank you to all our wonderful sponsors!
 
-##General Sponsorship FAQ
+## General Sponsorship FAQ
 
-####Can we present a talk at the event we sponsor?
-Yes as long as the talk is not a sales pitch. Another option is a 2-5 minute intro at the beginning of the event. 
+#### Can we present a talk at the event we sponsor?
+Yes as long as the talk is not a sales pitch. Another option is a 2-5 minute intro at the beginning of the event.
 
-####Do you offer annual sponsorship packages? 
-In an effort to keep our meetup events neutral, we mostly welcome ad hoc sponsorships. If you are interested in a recurring sponsorship, please contact Docker at meetups@docker.com 
-						
-####What is the agenda for a typical meetup?
-A typical meetup involves a few speaker presentations and some time for Q&A. Speaker presentations usually vary from one to three presenters who typically speak from 30 minutes to one hour. Events usually start in the evening around 6-7PM. Your local organizer contact will be able to give you the full details for their city. 
+#### Do you offer annual sponsorship packages?
+In an effort to keep our meetup events neutral, we mostly welcome ad hoc sponsorships. If you are interested in a recurring sponsorship, please contact Docker at meetups@docker.com
+
+#### What is the agenda for a typical meetup?
+A typical meetup involves a few speaker presentations and some time for Q&A. Speaker presentations usually vary from one to three presenters who typically speak from 30 minutes to one hour. Events usually start in the evening around 6-7PM. Your local organizer contact will be able to give you the full details for their city.
 
 
 ## Venue Host FAQ
 
-####How many guests will be invited? 
-The entire meetup group will be invited but the actual rsvp number is up to the capacity of your venue. 
+#### How many guests will be invited?
+The entire meetup group will be invited but the actual rsvp number is up to the capacity of your venue.
 
-####As a venue host, what do I need to provide?				
-As the venue host, you will provide the event space, Wi-Fi and A/V equipment (microphone and projection capabilities). Please confirm with your local organizer contact. 
+#### As a venue host, what do I need to provide?				
+As the venue host, you will provide the event space, Wi-Fi and A/V equipment (microphone and projection capabilities). Please confirm with your local organizer contact.
 
-####Do I need to sponsor food and beverages?
+#### Do I need to sponsor food and beverages?
 While we often secure a separate sponsor for food and beverages, many venues are also able to provide food and beverages for the event. A typical meal is pizza and a selection of soft drinks and beer, but other meal options are definitely well-received by the attendees.
 
 ## Food/ Beverage Sponsor FAQ			
- 		 	 	 				
-####Do we need to provide vegetarian/gluten-free/vegan meal options? 
+
+#### Do we need to provide vegetarian/gluten-free/vegan meal options?
 We ask for a vegetarian option to be served but we do not require vegan or gluten-­free options.
 
-####What is a typical meal that is served look like? 
-A typical meal is pizza and a selection of soft drinks and beer. Talk to your local organizer for average prices. 
+#### What is a typical meal that is served look like? 
+A typical meal is pizza and a selection of soft drinks and beer. Talk to your local organizer for average prices.

--- a/Organizers/guidelines.md
+++ b/Organizers/guidelines.md
@@ -1,46 +1,46 @@
-#Welcome to the Docker Organizer program! 
- 
-Docker meetups bring together people who are interested in, use, develop, and support the Docker ecosystem. Whether you are just starting out, or have been organizing meetups for the past few years, we really appreciate your commitment and are very grateful for your contributions to the Docker Community. 
- 
-By holding the organizer or co-organizer leadership position, you are participating in this program and shall agree to abide by the following program guidelines. This is to ensure that Docker meetup organizers are a respected and professional group demonstrating a positive impact in the Docker ecosystem. 
- 
+# Welcome to the Docker Organizer program!
+
+Docker meetups bring together people who are interested in, use, develop, and support the Docker ecosystem. Whether you are just starting out, or have been organizing meetups for the past few years, we really appreciate your commitment and are very grateful for your contributions to the Docker Community.
+
+By holding the organizer or co-organizer leadership position, you are participating in this program and shall agree to abide by the following program guidelines. This is to ensure that Docker meetup organizers are a respected and professional group demonstrating a positive impact in the Docker ecosystem.
+
 The document is not a comprehensive list of do’s and don’ts, but rather a living set of guidelines to follow that we will continue to refine as the program matures. Our goal is to raise awareness of the potential for actions that could negatively impact members of the community, not restrict the diversity of ideas and expression.
- 
+
 You are responsible for keeping abreast of changes to this document. If you need further clarification or are unable to fulfill any of the following guidelines, please let us know at your earliest convenience. 
 
 # Embody the Docker Community Code of Conduct
 
-All Docker community members should strive to follow our community [Code of Conduct](https://github.com/docker/code-of-conduct). As a Docker organizer, it is especially important to lead by showing model behavior at all times, both in person and online.  
+All Docker community members should strive to follow our community [Code of Conduct](https://github.com/docker/code-of-conduct). As a Docker organizer, its especially important to lead by showing model behavior at all times, both in person and online.  
 
-# Understand Docker beyond containers. 
+# Understand Docker beyond containers.
 
 As meetup organizers, you understand that Docker is an evolving platform stack. Ideally, you have a good understanding of all the pieces (Engine, Swarm, Machine, Compose, etc.) and how they fit together. You may feature Docker ecosystem tools at the local meetups your organize but you are still enthusiastic about Docker as a whole technology and platform.
 
-#Be a force for good in the community
-	
+# Be a force for good in the community
+
 - Promote and support inclusivity, respect, and professionalism in the tech community.  
-- Strive to keep the group active with frequent meetups and presentations on relevant content (including the latest Docker releases and cool projects using Docker products). If you can no longer commit to being an organizer, struggle to find good speakers or sponsors, please give us a heads up so that we can help out. 
+- Strive to keep the group active with frequent meetups and presentations on relevant content (including the latest Docker releases and cool projects using Docker products). If you can no longer commit to being an organizer, struggle to find good speakers or sponsors, please give us a heads up so that we can help out.
 - Ensure that all participants can freely and openly share ideas in a safe and welcoming environment that encourages mutual respect and collaboration.
-- Keep up-to-date on the latest technological advances in Docker and the ecosystem. 
-- Collaborate with the Docker Community team to support the organization of Docker-centric meetups and local editions of global meetup campaigns (Docker Birthday, Global Hack Day, etc) in your local community. 
+- Keep up-to-date on the latest technological advances in Docker and the ecosystem.
+- Collaborate with the Docker Community team to support the organization of Docker-centric meetups and local editions of global meetup campaigns (Docker Birthday, Global Hack Day, etc) in your local community.
 
-#Curate balanced and accurate content
+# Curate balanced and accurate content
 
-- When selecting the content of the meetups and/or using program resources to produce content, prioritize featuring Docker-native solutions over others. 
+- When selecting the content of the meetups and/or using program resources to produce content, prioritize featuring Docker-native solutions over others.
 - Be respectful when mentioning other vendors, technologies, and communities in the ecosystem.
-- Select content that is educational, accurate, and free from sales pitches. 
+- Select content that is educational, accurate, and free from sales pitches.
 - Do not accept talks which slander or publish libel against Docker or other people and companies.
-- Be rigorous in assessing the content submitted by potential speakers. If you need help validating results and analyses, reach out for assistance. 
+- Be rigorous in assessing the content submitted by potential speakers. If you need help validating results and analyses, reach out for assistance.
 - When selecting events to promote, be sure the event features Docker-native solutions in a capacity and highlight that information in the body of the message.
-- If you experience difficulties with Docker products or programs, give us the opportunity to address your feedback in advance. 
-- Make sure you're subscribed to the Docker Organizers mailing list to stay informated about the latest Docker News and community activities
+- If you experience difficulties with Docker products or programs, give us the opportunity to address your feedback in advance.
+- Make sure you're subscribed to the Docker Organizers mailing list to stay informed about the latest Docker News and community activities
 
-#Enforcing these Community Guidelines
+# Enforcing these Community Guidelines
 
 Docker reserves the right to remove any member from the Organizer program for violating these guidelines. In the event of a violation, the Docker community team will review the situation and determine the consequences on a case by case basis. When an organizer is removed from the program, we retire the remaining benefits and his or her access to Docker Organizer resources.
 
 #Additional Resources
 
 - [Docker Meetup Guide](https://github.com/docker/community/blob/master/Organizers/Resources/Docker%20Meetup%20Guide.md)
-- [Docker Meetup FAQ] (https://github.com/docker/community/blob/master/Organizers/Resources/Docker%20meetup%20FAQ.md)
-- [Meetup Sponsorship Guidelines] (https://github.com/docker/community/blob/master/Organizers/Resources/sponsorship%20guidelines.md)
+- [Docker Meetup FAQ](https://github.com/docker/community/blob/master/Organizers/Resources/Docker%20meetup%20FAQ.md)
+- [Meetup Sponsorship Guidelines](https://github.com/docker/community/blob/master/Organizers/Resources/sponsorship%20guidelines.md)

--- a/README.md
+++ b/README.md
@@ -1,49 +1,49 @@
 # Docker Community
 
-Welcome to the Docker Community repo! This repo aims to centralize content (HOW-TOs, scripts, slides, etc) curated by the Docker Team for the Docker Community. The main objective is to help members of the Docker community who share similar interests to learn from & collaborate with each other during Docker Meetups. 
+Welcome to the Docker Community repo! This repo aims to centralize content (HOW-TOs, scripts, slides, etc) curated by the Docker Team for the Docker Community. The main objective is to help members of the Docker community who share similar interests to learn from & collaborate with each other during Docker Meetups.
 
 # Become an active member of the Docker Community
 
-[Sign up here] (https://community.docker.com/registrations/groups/4316) to get involved as an active member of the Docker community!
+[Sign up here](https://community.docker.com/registrations/groups/4316) to get involved as an active member of the Docker community!
 
 By joining this program you'll have the opportunity to become a more informed and engaged member of the Docker community. More specifically, benefits include:
 - Access to the Docker Community directory and chat channels
 - Latest product updates, release notes and curated resources: tutorials, hands-on labs, code samples, White papers, etc.
-- Targeted invites and promo codes for Docker events or events sponsored by Docker. 
+- Targeted invites and promo codes for Docker events or events sponsored by Docker.
 - Priority access to beta programs
 - Opportunities to get involved as a user / customer reference, mentor, speaker, blogger, meetup organizer and more!
 
-Eveyone is welcome to join the Docker Community as long as long as they comply with our [Code of Conduct] (https://github.com/docker/code-of-conduct/blob/master/code-of-conduct.md).
+Everyone is welcome to join the Docker Community as long as long as they comply with our [Code of Conduct](https://github.com/docker/code-of-conduct/blob/master/code-of-conduct.md).
 
-Don't hesitate to [contact us](mailto:meetups@docker.com) if you have questions or want to get involved as a meetup organizers, speakers, sponsors, etc.
+Don't hesitate to [contact us](mailto:meetups@docker.com) if you have questions or want to get involved as meetup organizers, speakers, sponsors, etc.
 
-#Ressources
+# Resources
 
-#### [Official Docker Tutorials] (https://github.com/docker/labs)
+#### [Official Docker Tutorials](https://github.com/docker/labs)
 This repo contains official Docker tutorials authored both by Docker, Inc and by members of the community. It's a growing repo which we intend to continue to grow, with help from the community.
 
-#### [Docker Blog] (https://blog.docker.com/)
+#### [Docker Blog](https://blog.docker.com/)
 The Docker Blog is a great resource to find content! We post the latest Docker news including new releases and events like DockerCon there.
 
 For our curated collection of content from the community, check out this page: [https://blog.docker.com/curated](https://blog.docker.com/curated)
 
 #### [Docker Forum](https://forums.docker.com/)
 
-This is a public forum for users to discuss questions and explore current design patterns and best practices about Docker and related projects in the Docker Ecosystem. To participate, just log in with your Docker Hub account. 
+This is a public forum for users to discuss questions and explore current design patterns and best practices about Docker and related projects in the Docker Ecosystem. To participate, just log in with your Docker Hub account.
 
-####[Docker Weekly](https://www.docker.com/newsletter-subscription)
+#### [Docker Weekly](https://www.docker.com/newsletter-subscription)
 Get the latest Docker news straight to your inbox! This weekly newsletter highlights content from the community along with the latest Docker news.
 
-Read the Docker Weekly archives to catch up on all of the latest Docker news and hacks : [https://blog.docker.com/docker-weekly-archives/](https://blog.docker.com/docker-weekly-archives)
+Read the Docker Weekly archives to catch up on all of the latest Docker news and hacks: [https://blog.docker.com/docker-weekly-archives/](https://blog.docker.com/docker-weekly-archives)
 
-#### [Docker Docs] (https://docs.docker.com/)
+#### [Docker Docs](https://docs.docker.com/)
 Get all the info on the different Docker projects with our docs.
 
-#### [Slideshare] (http://www.slideshare.net/docker)
+#### [Slideshare](http://www.slideshare.net/docker)
 Another great resource for finding content! Docker’s Slideshare account has slide decks from Docker presentations - you’re welcome to use and/or modify these slides when presenting to your own meetup group.
 
-#### [YouTube] (https://www.youtube.com/user/dockerrun)
+#### [YouTube](https://www.youtube.com/user/dockerrun)
 Check out our YouTube page for videos of recorded talks from DockerCon, webinars and other meetups.
 
 #### Social Media
-Follow us on [Twitter] (https://twitter.com/docker), join the Docker community on [Google+](https://plus.google.com/u/0/communities/108146856671494713993), like Docker on [Facebook](https://www.facebook.com/docker.run) and join the Docker Users Group on [LinkedIn] (https://www.linkedin.com/company/docker) 
+Follow us on [Twitter](https://twitter.com/docker), join the Docker community on [Google+](https://plus.google.com/u/0/communities/108146856671494713993), like Docker on [Facebook](https://www.facebook.com/docker.run) and join the Docker Users Group on [LinkedIn](https://www.linkedin.com/company/docker)

--- a/contribute.md
+++ b/contribute.md
@@ -4,9 +4,9 @@ Thank you so much for your interest in contributing to the [Docker](https://dock
 
 Just a few quick things to be aware of before you get started.
 
-We welcome issues and pull requests for either adding new ressources to the [Docker Meetup Content (DMC)] (https://github.com/docker/community/tree/master/Docker-Meetup-Content) lists of curated ressources. This is a repository for tutorials that use Docker based projects as much as possible. So if there’s a Docker tool for what you’re describing, please use that.
+We welcome issues and pull requests for either adding new resources to the [Docker Meetup Content (DMC)](https://github.com/docker/community/tree/master/Docker-Meetup-Content) lists of curated resources. This is a repository for tutorials that use Docker based projects as much as possible. So if there’s a Docker tool for what you’re describing, please use that.
 
-Anything you contribute will be under an Apache license. Docker will choose which tutorials & ressources to accept and reject. Likewise, anything posted here may be forked by anyone on GitHub.
+Anything you contribute will be under an Apache license. Docker will choose which tutorials and resources to accept and reject. Likewise, anything posted here may be forked by anyone on GitHub.
 
 We will be following the a lightweight version of the Docker contribution policies and procedures as explained in
 - [Docker documentation](https://docs.docker.com)


### PR DESCRIPTION
Fixed a few typos and fixed spacing in README to render Markdown correctly. GitHub renders links OK on docker/community but when you view README individually, the links are broken.